### PR TITLE
fix: combobox dropdown renders behind map and empty state always visible

### DIFF
--- a/src/components/LocationCombobox.tsx
+++ b/src/components/LocationCombobox.tsx
@@ -103,7 +103,9 @@ export default function LocationCombobox({
                 <ComboboxSeparator />
               </>
             )}
-            <ComboboxEmpty>Няма намерени резултати.</ComboboxEmpty>
+            {filteredGroups.length === 0 && (
+              <ComboboxEmpty>Няма намерени резултати.</ComboboxEmpty>
+            )}
             {filteredGroups.map((group) => (
               <ComboboxGroup key={group.value}>
                 <ComboboxItem

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -105,7 +105,7 @@ function ComboboxContent({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="isolate z-50"
+        className="isolate z-[9999]"
       >
         <ComboboxPrimitive.Popup
           data-slot="combobox-content"

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -105,7 +105,7 @@ function ComboboxContent({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="isolate z-[9999]"
+        className="isolate z-[1000]"
       >
         <ComboboxPrimitive.Popup
           data-slot="combobox-content"


### PR DESCRIPTION
- Raise positioner z-index to 9999 so the dropdown appears above Leaflet's map layers
- Conditionally render ComboboxEmpty only when filteredGroups is empty, fixing always-visible no-results text