### PR TITLE
Display the марка in list view and map popup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# 100 НТО
+
+## Code comments
+
+Default to no comment. The code should speak for itself: reach for a clearer
+name, a smaller function, or an extracted constant before reaching for a
+comment.
+
+Write one only when it carries something the code cannot:
+
+- **Why, not what** — a constraint, a trade-off, a rejected alternative, or a
+  bug it works around.
+- **Non-local facts** — why a test picks a specific fixture (why `Видин` and
+  not another city), why an order matters, an external quirk the reader would
+  otherwise have to discover.
+- **Absences** — something deliberately *not* done, since nothing in the code
+  marks it.
+
+Do not write restatements of the line below, docblocks that only re-list the
+name and params, section banners, or narration of the edit being made.
+
+## Domain language
+
+The app tracks two collectibles per site. Use the Bulgarian terms in prose and
+the English ones in code:
+
+- **печат** / `stamp` — universal, every site has one. `false` means not yet
+  collected.
+- **марка** / `sticker` — three-state: `true` collected, `false` not collected,
+  `null` не се предлага at this site.
+
+All reasoning about these lives in `src/lib/collectionStatus.ts` — a pure,
+framework-free module. Consumers ask it rather than testing the fields
+themselves, so the rules cannot drift between the list, the map, the filters and
+the progress line.
+
+## Testing
+
+- `npm test` — vitest, unit and component.
+- `npm run test:e2e` — playwright.
+
+End-to-end assertions target stable test attributes (`data-testid`,
+`data-pin-status`), never colours or class names, which are expected to change.

--- a/src/app/sites/map/page.tsx
+++ b/src/app/sites/map/page.tsx
@@ -43,8 +43,6 @@ export default function SitesMapPage() {
                 {city.city} &bull; №{site.number}
               </div>
 
-              {/* Pin colour reads a collected марка and an unavailable one as
-                  the same complete state — the popup is where they differ. */}
               <CollectionIcons
                 state={site}
                 className="mt-2 flex items-center gap-1.5 text-gray-700"

--- a/src/app/sites/map/page.tsx
+++ b/src/app/sites/map/page.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import Image from "next/image";
 import dynamic from "next/dynamic";
 import { randomId } from "@/utils";
+import { CollectionIcons } from "@/components/CollectionIcons";
 import { deriveStatus } from "@/lib/collectionStatus";
 import { useSitesContext } from "../context";
 
@@ -41,6 +42,13 @@ export default function SitesMapPage() {
               <div className="text-gray-500 text-xs">
                 {city.city} &bull; №{site.number}
               </div>
+
+              {/* Pin colour reads a collected марка and an unavailable one as
+                  the same complete state — the popup is where they differ. */}
+              <CollectionIcons
+                state={site}
+                className="mt-2 flex items-center gap-1.5 text-gray-700"
+              />
             </div>
           ),
         })),

--- a/src/components/CollectionIcons.tsx
+++ b/src/components/CollectionIcons.tsx
@@ -22,6 +22,12 @@ interface CollectionIconsProps {
 const iconClass = "w-5 h-5";
 
 export const CollectionIcons = ({ state, className }: CollectionIconsProps) => {
+  const unavailable = stickerIsUnavailable(state);
+
+  if (!state.stamp && state.sticker !== true && !unavailable) {
+    return null;
+  }
+
   return (
     <span className={className}>
       {state.stamp && (
@@ -46,7 +52,7 @@ export const CollectionIcons = ({ state, className }: CollectionIconsProps) => {
         </StickerIcon>
       )}
 
-      {stickerIsUnavailable(state) && (
+      {unavailable && (
         <SquareSlashIcon
           role="img"
           aria-label="Няма марка за този обект"

--- a/src/components/CollectionIcons.tsx
+++ b/src/components/CollectionIcons.tsx
@@ -6,24 +6,19 @@ import {
 } from "@/lib/collectionStatus";
 
 /**
- * The icon trio for a site's печат and марка.
+ * Shared by the list view and the map popup: pin colour reads "марка collected"
+ * and "no марка offered" as the same complete state, so these icons are the only
+ * place that distinction surfaces.
  *
- * Shared by the list view and the map popup so the two presentations cannot
- * drift apart. The popup matters in particular: pin colour deliberately reads
- * "марка collected" and "no марка offered" as the same complete state, so these
- * icons are the only place that distinction surfaces.
- *
- * Icons are presence-based — an item that is not collected renders nothing at
- * all, rather than a dimmed icon. At this size a faded icon reads as a
- * different icon, not as an absent one.
+ * An uncollected item renders nothing rather than a dimmed icon — at this size a
+ * faded icon reads as a different icon, not as an absent one.
  */
 interface CollectionIconsProps {
   state: CollectionState;
   className?: string;
 }
 
-// Colour is inherited so each consumer can sit the trio on its own background —
-// white over a photograph in the list, dark ink in the map popup.
+// Colour is inherited so each consumer can set it for its own background.
 const iconClass = "w-5 h-5";
 
 export const CollectionIcons = ({ state, className }: CollectionIconsProps) => {

--- a/src/components/CollectionIcons.tsx
+++ b/src/components/CollectionIcons.tsx
@@ -1,0 +1,66 @@
+import { BadgeCheckIcon, SquareSlashIcon, StickerIcon } from "lucide-react";
+
+import {
+  stickerIsUnavailable,
+  type CollectionState,
+} from "@/lib/collectionStatus";
+
+/**
+ * The icon trio for a site's печат and марка.
+ *
+ * Shared by the list view and the map popup so the two presentations cannot
+ * drift apart. The popup matters in particular: pin colour deliberately reads
+ * "марка collected" and "no марка offered" as the same complete state, so these
+ * icons are the only place that distinction surfaces.
+ *
+ * Icons are presence-based — an item that is not collected renders nothing at
+ * all, rather than a dimmed icon. At this size a faded icon reads as a
+ * different icon, not as an absent one.
+ */
+interface CollectionIconsProps {
+  state: CollectionState;
+  className?: string;
+}
+
+// Colour is inherited so each consumer can sit the trio on its own background —
+// white over a photograph in the list, dark ink in the map popup.
+const iconClass = "w-5 h-5";
+
+export const CollectionIcons = ({ state, className }: CollectionIconsProps) => {
+  return (
+    <span className={className}>
+      {state.stamp && (
+        <BadgeCheckIcon
+          role="img"
+          aria-label="Събран печат"
+          data-testid="stamp-icon"
+          className={iconClass}
+        >
+          <title>Събран печат</title>
+        </BadgeCheckIcon>
+      )}
+
+      {state.sticker === true && (
+        <StickerIcon
+          role="img"
+          aria-label="Събрана марка"
+          data-testid="sticker-icon"
+          className={iconClass}
+        >
+          <title>Събрана марка</title>
+        </StickerIcon>
+      )}
+
+      {stickerIsUnavailable(state) && (
+        <SquareSlashIcon
+          role="img"
+          aria-label="Няма марка за този обект"
+          data-testid="sticker-unavailable-icon"
+          className={iconClass}
+        >
+          <title>Няма марка за този обект</title>
+        </SquareSlashIcon>
+      )}
+    </span>
+  );
+};

--- a/src/components/SiteList.tsx
+++ b/src/components/SiteList.tsx
@@ -1,5 +1,7 @@
 import Image from "next/image";
-import { BadgeCheckIcon } from "lucide-react";
+
+import { CollectionIcons } from "@/components/CollectionIcons";
+import type { StickerState } from "@/lib/collectionStatus";
 
 type SiteListData = {
   name: string;
@@ -7,6 +9,7 @@ type SiteListData = {
   image: string;
   link: string;
   stamp: boolean;
+  sticker: StickerState;
 };
 
 interface SiteListProps {
@@ -48,18 +51,12 @@ export const SiteList = ({ siteList }: SiteListProps) => {
                   className="absolute inset-x-0 bottom-0 h-28 bg-linear-to-t from-black opacity-20"
                 />
 
-                <p className="relative text-lg font-semibold text-white">
-                  {site.stamp && (
-                    <BadgeCheckIcon
-                      role="img"
-                      aria-label="Събран печат"
-                      data-testid="stamp-icon"
-                      className="w-5 h-5"
-                    >
-                      <title>Събран печат</title>
-                    </BadgeCheckIcon>
-                  )}
-                </p>
+                <CollectionIcons
+                  state={site}
+                  // The photographs run from near-black to near-white, so
+                  // legibility comes from the shadow, not from the fill colour.
+                  className="relative flex items-center gap-1.5 text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)]"
+                />
               </div>
             </div>
           </a>

--- a/src/components/SiteList.tsx
+++ b/src/components/SiteList.tsx
@@ -53,8 +53,8 @@ export const SiteList = ({ siteList }: SiteListProps) => {
 
                 <CollectionIcons
                   state={site}
-                  // The photographs run from near-black to near-white, so
-                  // legibility comes from the shadow, not from the fill colour.
+                  // Photographs run near-black to near-white, so legibility
+                  // comes from the shadow rather than the fill colour.
                   className="relative flex items-center gap-1.5 text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)]"
                 />
               </div>

--- a/src/components/__tests__/CollectionIcons.test.tsx
+++ b/src/components/__tests__/CollectionIcons.test.tsx
@@ -22,6 +22,15 @@ describe("CollectionIcons", () => {
     expect(unavailable()).toBeNull();
   });
 
+  it("renders no wrapper at all when there is nothing to show", () => {
+    // An empty wrapper would still apply the consumer's spacing classes.
+    const { container } = render(
+      <CollectionIcons state={state(false, false)} className="mt-2" />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
   it("shows only the печат when the марка is still outstanding", () => {
     render(<CollectionIcons state={state(true, false)} />);
 

--- a/src/components/__tests__/CollectionIcons.test.tsx
+++ b/src/components/__tests__/CollectionIcons.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import { CollectionIcons } from "@/components/CollectionIcons";
+import type { CollectionState } from "@/lib/collectionStatus";
+
+const state = (stamp: boolean, sticker: boolean | null): CollectionState => ({
+  stamp,
+  sticker,
+});
+
+const stamp = () => screen.queryByTestId("stamp-icon");
+const sticker = () => screen.queryByTestId("sticker-icon");
+const unavailable = () => screen.queryByTestId("sticker-unavailable-icon");
+
+describe("CollectionIcons", () => {
+  it("shows nothing for a site with neither collectible", () => {
+    render(<CollectionIcons state={state(false, false)} />);
+
+    expect(stamp()).toBeNull();
+    expect(sticker()).toBeNull();
+    expect(unavailable()).toBeNull();
+  });
+
+  it("shows only the печат when the марка is still outstanding", () => {
+    render(<CollectionIcons state={state(true, false)} />);
+
+    expect(stamp()).not.toBeNull();
+    expect(sticker()).toBeNull();
+    expect(unavailable()).toBeNull();
+  });
+
+  it("shows both icons when both collectibles are in hand", () => {
+    render(<CollectionIcons state={state(true, true)} />);
+
+    expect(stamp()).not.toBeNull();
+    expect(sticker()).not.toBeNull();
+    expect(unavailable()).toBeNull();
+  });
+
+  it("shows the unavailable icon, and no марка icon, where no марка is offered", () => {
+    render(<CollectionIcons state={state(true, null)} />);
+
+    expect(stamp()).not.toBeNull();
+    expect(sticker()).toBeNull();
+    expect(unavailable()).not.toBeNull();
+  });
+
+  it("shows the unavailable icon even before the печат is collected", () => {
+    render(<CollectionIcons state={state(false, null)} />);
+
+    expect(stamp()).toBeNull();
+    expect(unavailable()).not.toBeNull();
+  });
+
+  it("shows a марка collected without its печат", () => {
+    render(<CollectionIcons state={state(false, true)} />);
+
+    expect(stamp()).toBeNull();
+    expect(sticker()).not.toBeNull();
+  });
+
+  it("renders each icon as a distinct shape", () => {
+    const { container } = render(<CollectionIcons state={state(true, true)} />);
+    const { container: absent } = render(
+      <CollectionIcons state={state(false, null)} />,
+    );
+
+    const paths = (root: HTMLElement, testId: string) =>
+      root.querySelector(`[data-testid='${testId}']`)?.innerHTML;
+
+    expect(paths(container, "stamp-icon")).not.toBe(
+      paths(container, "sticker-icon"),
+    );
+    expect(paths(container, "stamp-icon")).not.toBe(
+      paths(absent, "sticker-unavailable-icon"),
+    );
+  });
+
+  it("labels every icon in Bulgarian for screen readers", () => {
+    render(<CollectionIcons state={state(true, true)} />);
+
+    expect(screen.getByRole("img", { name: "Събран печат" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Събрана марка" })).toBeTruthy();
+
+    render(<CollectionIcons state={state(true, null)} />);
+
+    expect(
+      screen.getByRole("img", { name: "Няма марка за този обект" }),
+    ).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/CollectionIcons.test.tsx
+++ b/src/components/__tests__/CollectionIcons.test.tsx
@@ -60,30 +60,41 @@ describe("CollectionIcons", () => {
     expect(sticker()).not.toBeNull();
   });
 
+  // The <title> differs per icon, so comparing innerHTML would pass even for
+  // identical glyphs. Compare the drawn geometry only.
+  const geometry = (root: HTMLElement, testId: string) =>
+    Array.from(root.querySelectorAll(`[data-testid='${testId}'] > *`))
+      .filter((el) => el.tagName !== "title")
+      .map((el) => el.outerHTML)
+      .join("");
+
   it("renders each icon as a distinct shape", () => {
-    const { container } = render(<CollectionIcons state={state(true, true)} />);
-    const { container: absent } = render(
-      <CollectionIcons state={state(false, null)} />,
+    const { container, rerender } = render(
+      <CollectionIcons state={state(true, true)} />,
     );
 
-    const paths = (root: HTMLElement, testId: string) =>
-      root.querySelector(`[data-testid='${testId}']`)?.innerHTML;
+    const stamp = geometry(container, "stamp-icon");
+    const sticker = geometry(container, "sticker-icon");
 
-    expect(paths(container, "stamp-icon")).not.toBe(
-      paths(container, "sticker-icon"),
-    );
-    expect(paths(container, "stamp-icon")).not.toBe(
-      paths(absent, "sticker-unavailable-icon"),
-    );
+    rerender(<CollectionIcons state={state(false, null)} />);
+    const unavailable = geometry(container, "sticker-unavailable-icon");
+
+    expect(stamp).not.toBe("");
+    expect(sticker).not.toBe("");
+    expect(unavailable).not.toBe("");
+
+    expect(stamp).not.toBe(sticker);
+    expect(stamp).not.toBe(unavailable);
+    expect(sticker).not.toBe(unavailable);
   });
 
   it("labels every icon in Bulgarian for screen readers", () => {
-    render(<CollectionIcons state={state(true, true)} />);
+    const { rerender } = render(<CollectionIcons state={state(true, true)} />);
 
     expect(screen.getByRole("img", { name: "Събран печат" })).toBeTruthy();
     expect(screen.getByRole("img", { name: "Събрана марка" })).toBeTruthy();
 
-    render(<CollectionIcons state={state(true, null)} />);
+    rerender(<CollectionIcons state={state(true, null)} />);
 
     expect(
       screen.getByRole("img", { name: "Няма марка за този обект" }),

--- a/src/data/places.json
+++ b/src/data/places.json
@@ -236,7 +236,7 @@
         "number": "6",
         "image": "/sites/btsbg/019-arheologicheski-muzei-nesebur.jpg",
         "link": "https://www.btsbg.org/100nto/arheologicheski-muzey",
-        "stamp": false,
+        "stamp": true,
         "sticker": false,
         "lat": 42.6583467,
         "lng": 27.7307281
@@ -341,7 +341,7 @@
         "image": "/sites/btsbg/027-arheologicheski-muzei-sozopol.jpg",
         "link": "https://www.btsbg.org/100nto/arheologicheski-muzey-0",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 42.4220168,
         "lng": 27.6935308
       }
@@ -373,7 +373,7 @@
         "image": "/sites/btsbg/029-regionalen-istoricheski-muzei-varna.jpg",
         "link": "https://www.btsbg.org/100nto/regionalen-istoricheski-muzey-0",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.207397,
         "lng": 27.915069
       },
@@ -393,7 +393,7 @@
         "image": "/sites/btsbg/031-aladja-manastir-050-00-b.jpg",
         "link": "https://www.btsbg.org/100nto/aladzha-manastir",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.2779995,
         "lng": 28.0151088
       },
@@ -445,7 +445,7 @@
         "image": "/sites/btsbg/035-tsarevets-veliko-tarnovo.jpg",
         "link": "https://www.btsbg.org/100nto/carevec",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.0835941,
         "lng": 25.6524479
       },
@@ -523,7 +523,7 @@
         "image": "/sites/btsbg/041-istoricheski-muzei-smolyan.jpg",
         "link": "https://www.btsbg.org/100nto/regionalen-istoricheski-muzey-8",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 41.5763396,
         "lng": 24.7146161
       },
@@ -533,7 +533,7 @@
         "image": "/sites/btsbg/042-planetarium-2.jpg",
         "link": "https://www.btsbg.org/100nto/planetarium",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 41.5759377,
         "lng": 24.7087044
       }
@@ -575,7 +575,7 @@
         "image": "/sites/btsbg/045-selo-momchilovtsi.jpg",
         "link": "https://www.btsbg.org/100nto/crkva-svkonstantin-i-elena-s-momchilovci",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 41.658922,
         "lng": 24.775795
       }
@@ -617,7 +617,7 @@
         "image": "/sites/btsbg/048-vruh-golyam-perelik-rodopi.jpg",
         "link": "https://www.btsbg.org/100nto/vrh-golyam-perelik-2191-m",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 41.602655,
         "lng": 24.574506
       },
@@ -637,7 +637,7 @@
         "image": "/sites/btsbg/050-trigradsko-jdrelo-rodopi.jpg",
         "link": "https://www.btsbg.org/100nto/trigradsko-zhdrelo",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 41.606779,
         "lng": 24.383308
       },
@@ -647,7 +647,7 @@
         "image": "/sites/btsbg/051-devil-s-throat-cave-40-0.jpg",
         "link": "https://www.btsbg.org/100nto/peshchera-dyavolsko-grlo",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 41.614885,
         "lng": 24.379129
       },
@@ -657,7 +657,7 @@
         "image": "/sites/btsbg/052-yagodinska-peshtera-rodopi.jpg",
         "link": "https://www.btsbg.org/100nto/yagodinska-peshchera",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 41.628997,
         "lng": 24.330018
       },
@@ -667,7 +667,7 @@
         "image": "/sites/btsbg/053-buinovsko-jdrelo-rodopi.jpg",
         "link": "https://www.btsbg.org/100nto/buynovsko-zhdrelo",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 41.649419,
         "lng": 24.335012
       },
@@ -725,7 +725,7 @@
         "image": "/sites/btsbg/057-arhitekturen-rezervat-shiroka-luka.jpg",
         "link": "https://www.btsbg.org/100nto/shiroka-lka-arhitekturen-rezervat",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 41.679066,
         "lng": 24.582239
       }
@@ -757,7 +757,7 @@
         "image": "/sites/btsbg/059-istoricheski-muzei-vidin.jpg",
         "link": "https://www.btsbg.org/100nto/istoricheski-muzey-1",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.988501,
         "lng": 22.878043
       },
@@ -767,7 +767,7 @@
         "image": "/sites/btsbg/060-krepost-baba-vida-vidin.jpg",
         "link": "https://www.btsbg.org/100nto/krepost-baba-vida",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.9929708,
         "lng": 22.886094
       }
@@ -1073,7 +1073,7 @@
         "image": "/sites/btsbg/084-kompleks-dvoretsa-balchik.jpg",
         "link": "https://www.btsbg.org/100nto/arhitekturen-parkov-kompleks-dvoreca",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.40456,
         "lng": 28.14708
       },
@@ -1083,7 +1083,7 @@
         "image": "/sites/btsbg/085-universitetska-botanicheska-gradina-balchik.jpg",
         "link": "https://www.btsbg.org/100nto/universitetska-botanicheska-gradina",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.403294,
         "lng": 28.143014
       }
@@ -1099,7 +1099,7 @@
         "image": "/sites/btsbg/086-istoricheski-muzei-kavarna.jpg",
         "link": "https://www.btsbg.org/100nto/istoricheski-muzey-kavarna",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.432195,
         "lng": 28.3401784
       }
@@ -1115,7 +1115,7 @@
         "image": "/sites/btsbg/087-arheologicheski-rezervat-kaliakra-nos-kaliakra.jpg",
         "link": "https://www.btsbg.org/100nto/arheologicheski-rezervat-kaliakra",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.360956,
         "lng": 28.465734
       }
@@ -1343,7 +1343,7 @@
         "image": "/sites/btsbg/105-troyanski-manastir.jpg",
         "link": "https://www.btsbg.org/100nto/troyanska-sveta-obitel-usp-bogorodichno",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 42.861901,
         "lng": 24.780859
       },
@@ -1673,7 +1673,7 @@
         "image": "/sites/btsbg/129-podzemen-minen-muzei-pernik.jpg",
         "link": "https://www.btsbg.org/100nto/podzemen-minen-muzey",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 42.609556,
         "lng": 23.029208
       }
@@ -1709,7 +1709,7 @@
         "image": "/sites/btsbg/132-panoramata-pleven.jpg",
         "link": "https://www.btsbg.org/100nto/panorama-plevenska-epopeya-1877-g",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.398811,
         "lng": 24.606231
       }
@@ -1853,7 +1853,7 @@
         "image": "/sites/btsbg/144-istoricheski-muzei-perushtitsa.jpg",
         "link": "https://www.btsbg.org/100nto/istoricheski-muzey-8",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 42.0556131,
         "lng": 24.5455523
       }
@@ -1931,7 +1931,7 @@
         "image": "/sites/btsbg/150-muzei-hristo-botev-kalofer.jpg",
         "link": "https://www.btsbg.org/100nto/nac-muzey-hristo-botev",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 42.611171,
         "lng": 24.97746
       },
@@ -1993,7 +1993,7 @@
         "image": "/sites/btsbg/155-bachkovski-manastir.jpg",
         "link": "https://www.btsbg.org/100nto/bachkovski-manastir",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 41.9417765,
         "lng": 24.8512692
       }
@@ -2365,7 +2365,7 @@
         "image": "/sites/btsbg/182-boyanska-cherkva-sofia.jpg",
         "link": "https://www.btsbg.org/100nto/nacionalen-muzey-boyanska-cherkva",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 42.644625,
         "lng": 23.266189
       },
@@ -2385,7 +2385,7 @@
         "image": "/sites/btsbg/184-voennoistoricheski-muzei-sofia.jpg",
         "link": "https://www.btsbg.org/100nto/nacionalen-voennoistoricheski-muzey",
         "stamp": true,
-        "sticker": false,
+        "sticker": null,
         "lat": 42.6887621,
         "lng": 23.3506491
       },
@@ -2495,7 +2495,7 @@
         "image": "/sites/btsbg/195-nacionalen-politehnicheski-muzei.jpg",
         "link": "https://www.btsbg.org/100nto/nacionalen-politehnicheski-muzey",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 42.7040528,
         "lng": 23.3119863
       },
@@ -2567,7 +2567,7 @@
         "image": "/sites/btsbg/201-site.jpg",
         "link": "https://www.btsbg.org/100nto/koprivshchica-air",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 42.640036,
         "lng": 24.357746
       }
@@ -2829,7 +2829,7 @@
         "image": "/sites/btsbg/220-muzei-chudomir-kazanluk.jpg",
         "link": "https://www.btsbg.org/100nto/literaturno-hudozhestven-muzey-chudomir",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 42.620149,
         "lng": 25.3982212
       }
@@ -3039,7 +3039,7 @@
         "image": "/sites/btsbg/235-regionalen-istoricheski-muzei-shumen.jpg",
         "link": "https://www.btsbg.org/100nto/regionalen-istoricheski-muzey-9",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.2703419,
         "lng": 26.9275297
       },
@@ -3059,7 +3059,7 @@
         "image": "/sites/btsbg/237-pametnik-1300-godini-balgaria-shumen.jpg",
         "link": "https://www.btsbg.org/100nto/pametnik-szdateli-na-blgarskata-drzhava",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.2621837,
         "lng": 26.9221503
       },
@@ -3069,7 +3069,7 @@
         "image": "/sites/btsbg/238-tombul-djamiya-shumen.jpg",
         "link": "https://www.btsbg.org/100nto/tombul-dzhamiya-sherif-halil-pasha-1744-g",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.269491,
         "lng": 26.90997
       }
@@ -3085,7 +3085,7 @@
         "image": "/sites/btsbg/239-arheologicheski-rezervat-pliska.jpg",
         "link": "https://www.btsbg.org/100nto/nacionalen-iar-pliska",
         "stamp": true,
-        "sticker": false,
+        "sticker": true,
         "lat": 43.3861559,
         "lng": 27.1310548
       }

--- a/tests/e2e/sites.spec.ts
+++ b/tests/e2e/sites.spec.ts
@@ -176,7 +176,6 @@ test.describe("Печат collection state", () => {
   const stickerIcons = "[data-testid='sticker-icon']";
   const unavailableIcons = "[data-testid='sticker-unavailable-icon']";
 
-  /** Opens a map URL and waits for leaflet to have drawn its pins. */
   const gotoMap = async (page: Page, url: string) => {
     await page.goto(url);
 
@@ -266,8 +265,7 @@ test.describe("Печат collection state", () => {
       );
 
     expect(statuses.length).toBeGreaterThan(0);
-    // A stamped site is partial until its марка arrives, then complete. Both
-    // are present in the dataset, so assert only that neither reads as "none".
+    // The dataset holds both, so assert the pair rather than a single status.
     expect(statuses.every((s) => s === "partial" || s === "complete")).toBe(
       true,
     );
@@ -303,10 +301,8 @@ test.describe("Печат collection state", () => {
     await expect(sites.first()).toBeVisible();
 
     const stamps = await page.locator(stampIcons).count();
-    const stickers = await page.locator("[data-testid='sticker-icon']").count();
+    const stickers = await page.locator(stickerIcons).count();
 
-    // Every марка in the dataset sits on a stamped site, and some stamped
-    // sites are still waiting for theirs.
     expect(stickers).toBeGreaterThan(0);
     expect(stickers).toBeLessThan(stamps);
   });
@@ -317,7 +313,7 @@ test.describe("Печат collection state", () => {
     await expect(page.locator("ul[role='list'] > li > a").first()).toBeVisible();
 
     expect(await page.locator(stampIcons).count()).toBe(0);
-    expect(await page.locator("[data-testid='sticker-icon']").count()).toBe(0);
+    expect(await page.locator(stickerIcons).count()).toBe(0);
   });
 
   test("the марка icon carries a Bulgarian screen-reader label", async ({
@@ -333,8 +329,7 @@ test.describe("Печат collection state", () => {
   test("a site offering no марка shows the unavailable icon", async ({
     page,
   }) => {
-    // Национален военноисторически музей is the one site in София that offers
-    // no марка; its stamped neighbours make the icon's distinctness visible.
+    // Национален военноисторически музей is the only София site with no марка.
     await page.goto("/sites/list?filters[location]=София");
 
     await expect(page.locator("ul[role='list'] > li > a").first()).toBeVisible();
@@ -343,7 +338,6 @@ test.describe("Печат collection state", () => {
     await expect(
       page.getByRole("img", { name: "Няма марка за този обект" }),
     ).toBeVisible();
-    // The absent марка is never also reported as collected.
     const row = page.locator("ul[role='list'] > li > a").filter({
       has: page.locator(unavailableIcons),
     });

--- a/tests/e2e/sites.spec.ts
+++ b/tests/e2e/sites.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 test.describe("Sites view navigation", () => {
   test("clicking Карта on list page navigates to /sites/map", async ({
@@ -173,6 +173,20 @@ test.describe("Location combobox (Град filter on sites)", () => {
 
 test.describe("Печат collection state", () => {
   const stampIcons = "[data-testid='stamp-icon']";
+  const stickerIcons = "[data-testid='sticker-icon']";
+  const unavailableIcons = "[data-testid='sticker-unavailable-icon']";
+
+  /** Opens a map URL and waits for leaflet to have drawn its pins. */
+  const gotoMap = async (page: Page, url: string) => {
+    await page.goto(url);
+
+    await expect(page.locator(".leaflet-container")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.locator("[data-pin-status]").first()).toBeVisible({
+      timeout: 10000,
+    });
+  };
 
   test("list view marks stamped sites and leaves the rest unmarked", async ({
     page,
@@ -233,7 +247,7 @@ test.describe("Печат collection state", () => {
     ).toBe(true);
   });
 
-  test("stamped sites render as partial while every марка is outstanding", async ({
+  test("stamped sites render as partial or complete, never as untouched", async ({
     page,
   }) => {
     await page.goto("/sites/map?filters[stamp]=collected");
@@ -252,7 +266,13 @@ test.describe("Печат collection state", () => {
       );
 
     expect(statuses.length).toBeGreaterThan(0);
-    expect(statuses.every((s) => s === "partial")).toBe(true);
+    // A stamped site is partial until its марка arrives, then complete. Both
+    // are present in the dataset, so assert only that neither reads as "none".
+    expect(statuses.every((s) => s === "partial" || s === "complete")).toBe(
+      true,
+    );
+    expect(statuses).toContain("partial");
+    expect(statuses).toContain("complete");
   });
 
   test("unstamped sites render as nothing collected", async ({ page }) => {
@@ -272,6 +292,90 @@ test.describe("Печат collection state", () => {
       );
 
     expect(statuses.every((s) => s === "none")).toBe(true);
+  });
+
+  test("the марка icon appears only on a subset of the stamped sites", async ({
+    page,
+  }) => {
+    await page.goto("/sites/list?filters[stamp]=collected");
+
+    const sites = page.locator("ul[role='list'] > li > a");
+    await expect(sites.first()).toBeVisible();
+
+    const stamps = await page.locator(stampIcons).count();
+    const stickers = await page.locator("[data-testid='sticker-icon']").count();
+
+    // Every марка in the dataset sits on a stamped site, and some stamped
+    // sites are still waiting for theirs.
+    expect(stickers).toBeGreaterThan(0);
+    expect(stickers).toBeLessThan(stamps);
+  });
+
+  test("unstamped sites show neither collection icon", async ({ page }) => {
+    await page.goto("/sites/list?filters[stamp]=not-collected");
+
+    await expect(page.locator("ul[role='list'] > li > a").first()).toBeVisible();
+
+    expect(await page.locator(stampIcons).count()).toBe(0);
+    expect(await page.locator("[data-testid='sticker-icon']").count()).toBe(0);
+  });
+
+  test("the марка icon carries a Bulgarian screen-reader label", async ({
+    page,
+  }) => {
+    await page.goto("/sites/list?filters[stamp]=collected");
+
+    await expect(
+      page.getByRole("img", { name: "Събрана марка" }).first(),
+    ).toBeVisible();
+  });
+
+  test("a site offering no марка shows the unavailable icon", async ({
+    page,
+  }) => {
+    // Национален военноисторически музей is the one site in София that offers
+    // no марка; its stamped neighbours make the icon's distinctness visible.
+    await page.goto("/sites/list?filters[location]=София");
+
+    await expect(page.locator("ul[role='list'] > li > a").first()).toBeVisible();
+
+    await expect(page.locator(unavailableIcons)).toHaveCount(1);
+    await expect(
+      page.getByRole("img", { name: "Няма марка за този обект" }),
+    ).toBeVisible();
+    // The absent марка is never also reported as collected.
+    const row = page.locator("ul[role='list'] > li > a").filter({
+      has: page.locator(unavailableIcons),
+    });
+    await expect(row.locator(stickerIcons)).toHaveCount(0);
+    await expect(row.locator(stampIcons)).toHaveCount(1);
+  });
+
+  test("a complete pin's popup shows both collection icons", async ({
+    page,
+  }) => {
+    // Both Видин sites have печат and марка, so any pin here is complete.
+    await gotoMap(page, "/sites/map?filters[location]=Видин");
+
+    await page.locator("[data-pin-status='complete']").first().click();
+
+    const popup = page.locator(".leaflet-popup");
+    await expect(popup.locator(stampIcons)).toBeVisible();
+    await expect(popup.locator(stickerIcons)).toBeVisible();
+  });
+
+  test("a partial pin's popup shows the печат without a марка", async ({
+    page,
+  }) => {
+    // Царево has a single site: stamped, марка still outstanding.
+    await gotoMap(page, "/sites/map?filters[location]=Царево");
+
+    await page.locator("[data-pin-status='partial']").first().click();
+
+    const popup = page.locator(".leaflet-popup");
+    await expect(popup.locator(stampIcons)).toBeVisible();
+    await expect(popup.locator(stickerIcons)).toHaveCount(0);
+    await expect(popup.locator(unavailableIcons)).toHaveCount(0);
   });
 
   test("a stale visited link falls back to showing every site", async ({


### PR DESCRIPTION
Closes #46 (slice 3 of #43).

## What changed

A shared `CollectionIcons` component renders the печат/марка icon trio from a site's collection state. Both the list view and the map popup consume it, so the two presentations cannot drift apart.

The popup matters specifically because pin colour reads "марка collected" and "no марка offered" as the same `complete` state — the icons are the only place that distinction surfaces.

- **Icons are presence-based.** Nothing renders for an uncollected item. A dimmed icon at 20px reads as a *different* icon rather than an absent one, so opacity was not used.
- **Colour is inherited**, letting each consumer sit the trio on its own background: white over the photograph in the list, dark ink in the popup. The list adds a drop shadow, because the site photographs run from near-black to near-white.
- **Map pins needed no change** — `deriveStatus` already accounted for the sticker.

`SquareSlashIcon` marks "no марка offered". `CircleSlashIcon` was the first choice but rendered as almost the same glyph as the round `BadgeCheckIcon` at this size; square vs circle is unmistakable. Verified against a screenshot both times.

## Data

Records the марки collected so far, and marks Национален военноисторически музей as offering no марка — which is what gives the e2e suite a real fourth state to assert against. The diff is field-level only, 36 changed lines.

## Tests

`tsc`, `lint`, the unit suite and all 38 e2e tests pass.

- Component tests cover all six stamp × sticker combinations exhaustively, plus the Bulgarian screen-reader labels and icon distinctness.
- E2E covers the icons and pin statuses against the real dataset, asserting on `data-testid` and `data-pin-status` rather than colours or class names.

One existing e2e test asserted that every stamped site's pin reads `partial`. That is no longer true now that марки exist, so it is relaxed to "partial or complete, never none", with assertions that both statuses appear.

## Note for the reviewer

The pre-commit React Doctor hook reports two findings in `SiteList.tsx` — a missing `sizes` on `next/image` and a static element with a click handler. Both are pre-existing and untouched by this change; `CollectionIcons.tsx` is clean. Worth a separate cleanup.