### PR TITLE
Show collection progress for печати and марки

### DIFF
--- a/src/app/sites/layout.tsx
+++ b/src/app/sites/layout.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { useMemo } from "react";
 import { usePathname } from "next/navigation";
 import data from "@/data/places.json";
+import { CollectionProgress } from "@/components/CollectionProgress";
 import Filter from "@/components/Filter";
 import LocationCombobox from "@/components/LocationCombobox";
 import ViewToggle from "@/components/ViewToggle";
 import { useSiteFilters } from "@/hooks/useSiteFilters";
+import { aggregateProgress } from "@/lib/collectionStatus";
 import { SitesProvider } from "./context";
 
 export default function SitesLayout({
@@ -31,6 +34,11 @@ export default function SitesLayout({
     filtered: filteredData.reduce((acc, city) => acc + city.sites.length, 0),
   };
 
+  const progress = useMemo(
+    () => aggregateProgress(data.flatMap((city) => city.sites)),
+    [],
+  );
+
   const currentView = pathname.startsWith("/sites/map") ? "map" : "list";
 
   return (
@@ -54,9 +62,13 @@ export default function SitesLayout({
           </div>
 
           <div className="flex items-center gap-x-5 pt-5 md:pt-0">
-            <div className="flex-1 text-sm italic">
-              <span className="md:hidden">{results.filtered} от {results.total}</span>
-              <span className="hidden md:inline">показване на {results.filtered} {results.filtered === 1 ? "резултат" : "резултата"} от общо {results.total}</span>
+            <div className="flex flex-1 flex-col gap-y-0.5 text-sm italic md:flex-row md:gap-x-4">
+              <span data-testid="filter-results">
+                <span className="md:hidden">{results.filtered} от {results.total}</span>
+                <span className="hidden md:inline">показване на {results.filtered} {results.filtered === 1 ? "резултат" : "резултата"} от общо {results.total}</span>
+              </span>
+
+              <CollectionProgress progress={progress} />
             </div>
 
             <ViewToggle

--- a/src/components/CollectionProgress.tsx
+++ b/src/components/CollectionProgress.tsx
@@ -1,0 +1,48 @@
+import type { CollectibleProgress, Progress } from "@/lib/collectionStatus";
+
+/**
+ * The figures cover the whole dataset and stay put while filters change: a
+ * denominator that moved with the filters would read as though the collection
+ * itself had shrunk. The neighbouring result count answers "how many are
+ * showing".
+ */
+export const CollectionProgress = ({ progress }: { progress: Progress }) => (
+  <span
+    data-testid="collection-progress"
+    className="flex gap-x-4 whitespace-nowrap"
+  >
+    <Collectible
+      testId="stamp-progress"
+      short="Печати"
+      long="събрани печати"
+      value={progress.stamps}
+    />
+    <Collectible
+      testId="sticker-progress"
+      short="Марки"
+      long="събрани марки"
+      value={progress.stickers}
+    />
+  </span>
+);
+
+const Collectible = ({
+  testId,
+  short,
+  long,
+  value,
+}: {
+  testId: string;
+  short: string;
+  long: string;
+  value: CollectibleProgress;
+}) => (
+  <span data-testid={testId}>
+    <span className="md:hidden">
+      {short} {value.collected}/{value.total}
+    </span>
+    <span className="hidden md:inline">
+      {long}: {value.collected} от {value.total}
+    </span>
+  </span>
+);

--- a/src/components/__tests__/CollectionProgress.test.tsx
+++ b/src/components/__tests__/CollectionProgress.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import { CollectionProgress } from "@/components/CollectionProgress";
+import { aggregateProgress } from "@/lib/collectionStatus";
+
+describe("CollectionProgress", () => {
+  it("shows both figures in the narrow and the wide phrasing", () => {
+    render(
+      <CollectionProgress
+        progress={{
+          stamps: { collected: 3, total: 10 },
+          stickers: { collected: 1, total: 7 },
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("stamp-progress")).toHaveTextContent(
+      "Печати 3/10събрани печати: 3 от 10",
+    );
+    expect(screen.getByTestId("sticker-progress")).toHaveTextContent(
+      "Марки 1/7събрани марки: 1 от 7",
+    );
+  });
+
+  // Guards the whole chain: a marka-less site must not inflate the denominator
+  // the component prints.
+  it("prints a марка denominator that omits sites offering no марка", () => {
+    render(
+      <CollectionProgress
+        progress={aggregateProgress([
+          { stamp: true, sticker: true },
+          { stamp: true, sticker: false },
+          { stamp: false, sticker: null },
+        ])}
+      />,
+    );
+
+    expect(screen.getByTestId("sticker-progress")).toHaveTextContent(
+      "събрани марки: 1 от 2",
+    );
+    expect(screen.getByTestId("stamp-progress")).toHaveTextContent(
+      "събрани печати: 2 от 3",
+    );
+  });
+});

--- a/src/components/__tests__/CollectionProgress.test.tsx
+++ b/src/components/__tests__/CollectionProgress.test.tsx
@@ -15,12 +15,13 @@ describe("CollectionProgress", () => {
       />,
     );
 
-    expect(screen.getByTestId("stamp-progress")).toHaveTextContent(
-      "Печати 3/10събрани печати: 3 от 10",
-    );
-    expect(screen.getByTestId("sticker-progress")).toHaveTextContent(
-      "Марки 1/7събрани марки: 1 от 7",
-    );
+    const stamps = screen.getByTestId("stamp-progress");
+    expect(stamps).toHaveTextContent(/Печати 3\/10/);
+    expect(stamps).toHaveTextContent(/събрани печати: 3 от 10/);
+
+    const stickers = screen.getByTestId("sticker-progress");
+    expect(stickers).toHaveTextContent(/Марки 1\/7/);
+    expect(stickers).toHaveTextContent(/събрани марки: 1 от 7/);
   });
 
   // Guards the whole chain: a marka-less site must not inflate the denominator

--- a/tests/e2e/sites.spec.ts
+++ b/tests/e2e/sites.spec.ts
@@ -381,3 +381,51 @@ test.describe("Печат collection state", () => {
     await expect(page).not.toHaveURL(/visited/);
   });
 });
+
+test.describe("Collection progress", () => {
+  const stampProgress = (page: Page) => page.getByTestId("stamp-progress");
+  const stickerProgress = (page: Page) => page.getByTestId("sticker-progress");
+
+  test("both collectibles are reported", async ({ page }) => {
+    await page.goto("/sites/list");
+
+    await expect(stampProgress(page)).toContainText(/печати: \d+ от \d+/);
+    await expect(stickerProgress(page)).toContainText(/марки: \d+ от \d+/);
+  });
+
+  test("the figures survive a city filter and the result count still shows", async ({
+    page,
+  }) => {
+    await page.goto("/sites/list");
+
+    const stamps = await stampProgress(page).innerText();
+    const stickers = await stickerProgress(page).innerText();
+    const results = await page.getByTestId("filter-results").innerText();
+
+    await page.getByPlaceholder("Търсене...").click();
+    await page
+      .locator('[data-slot="combobox-item"]')
+      .filter({ hasText: /^Банско$/ })
+      .click();
+
+    await expect(page).toHaveURL(
+      /filters\[location\]=%D0%91%D0%B0%D0%BD%D1%81%D0%BA%D0%BE/,
+    );
+    await expect(page.getByTestId("filter-results")).not.toHaveText(results);
+
+    await expect(stampProgress(page)).toHaveText(stamps);
+    await expect(stickerProgress(page)).toHaveText(stickers);
+  });
+
+  test("the figures survive a печат filter", async ({ page }) => {
+    await page.goto("/sites/list");
+
+    const stamps = await stampProgress(page).innerText();
+    const stickers = await stickerProgress(page).innerText();
+
+    await page.goto("/sites/list?filters[stamp]=collected");
+
+    await expect(stampProgress(page)).toHaveText(stamps);
+    await expect(stickerProgress(page)).toHaveText(stickers);
+  });
+});

--- a/tests/e2e/sites.spec.ts
+++ b/tests/e2e/sites.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Locator, type Page } from "@playwright/test";
 
 test.describe("Sites view navigation", () => {
   test("clicking Карта on list page navigates to /sites/map", async ({
@@ -386,6 +386,12 @@ test.describe("Collection progress", () => {
   const stampProgress = (page: Page) => page.getByTestId("stamp-progress");
   const stickerProgress = (page: Page) => page.getByTestId("sticker-progress");
 
+  // Snapshots must be taken the same way toHaveText reads the element, which is
+  // textContent. Capturing innerText instead would leave the "did not change"
+  // assertion below able to pass without comparing anything.
+  const textOf = async (locator: Locator) =>
+    (await locator.textContent()) ?? "";
+
   test("both collectibles are reported", async ({ page }) => {
     await page.goto("/sites/list");
 
@@ -398,9 +404,9 @@ test.describe("Collection progress", () => {
   }) => {
     await page.goto("/sites/list");
 
-    const stamps = await stampProgress(page).innerText();
-    const stickers = await stickerProgress(page).innerText();
-    const results = await page.getByTestId("filter-results").innerText();
+    const stamps = await textOf(stampProgress(page));
+    const stickers = await textOf(stickerProgress(page));
+    const results = await textOf(page.getByTestId("filter-results"));
 
     await page.getByPlaceholder("Търсене...").click();
     await page
@@ -420,8 +426,8 @@ test.describe("Collection progress", () => {
   test("the figures survive a печат filter", async ({ page }) => {
     await page.goto("/sites/list");
 
-    const stamps = await stampProgress(page).innerText();
-    const stickers = await stickerProgress(page).innerText();
+    const stamps = await textOf(stampProgress(page));
+    const stickers = await textOf(stickerProgress(page));
 
     await page.goto("/sites/list?filters[stamp]=collected");
 


### PR DESCRIPTION
Adds a progress line next to the existing filter-result count showing collected-versus-total for the печат and the марка.

- Figures come from `aggregateProgress` in `src/lib/collectionStatus.ts`; nothing is recomputed locally.
- Computed over the entire dataset, so they do not move when a filter is applied. The neighbouring result count still answers "how many are showing".
- The марка denominator excludes sites offering no марка (today: 39 от 246 печати, 33 от 245 марки).
- New `CollectionProgress` component follows the layout's existing narrow/wide phrasing split; on mobile the two lines stack above the view toggle.
- Tests: component tests for both phrasings and the excluded denominator; e2e cases asserting the figures are unchanged across a city filter and a печат filter. The aggregation itself was already covered in `collectionStatus.test.ts`, so no duplication there.

Closes #48
