### PR TITLE
feat: filter by марка independently of печат

### DIFF
--- a/src/app/sites/layout.tsx
+++ b/src/app/sites/layout.tsx
@@ -23,8 +23,11 @@ export default function SitesLayout({
     setSelectedLocation,
     stampFilter,
     setStampFilter,
+    stickerFilter,
+    setStickerFilter,
     citiesByRegion,
     stampFilters,
+    stickerFilters,
     filteredData,
     queryString,
   } = filters;
@@ -45,7 +48,7 @@ export default function SitesLayout({
     <>
       <section aria-labelledby="filter-heading" className="mx-auto py-6">
         <div className="flex flex-col md:flex-row md:items-center md:justify-between">
-          <div className="flex items-center gap-x-5">
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-3">
             <LocationCombobox
               name="Град"
               selectedValue={selectedLocation}
@@ -58,6 +61,13 @@ export default function SitesLayout({
               selectedValue={stampFilter}
               options={stampFilters}
               onFilterChanged={setStampFilter}
+            />
+
+            <Filter
+              name="Марка"
+              selectedValue={stickerFilter}
+              options={stickerFilters}
+              onFilterChanged={setStickerFilter}
             />
           </div>
 

--- a/src/hooks/__tests__/useSiteFilters.test.tsx
+++ b/src/hooks/__tests__/useSiteFilters.test.tsx
@@ -106,6 +106,132 @@ describe("useSiteFilters", () => {
     });
   });
 
+  // The fixture holds one site per collection state the sticker filter can
+  // distinguish: collected, not collected, and не се предлага.
+  describe("sticker filter", () => {
+    it("shows every site by default, including the one offering no марка", () => {
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(siteNames(result.current.filteredData)).toEqual([
+        "Стамп само",
+        "Нищо",
+        "Пълен",
+        "Без марка",
+        "Празен",
+      ]);
+    });
+
+    it("narrows to sites with a collected марка", () => {
+      withParams({ "filters[sticker]": "collected" });
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(siteNames(result.current.filteredData)).toEqual(["Пълен"]);
+    });
+
+    it("narrows to sites still missing an obtainable марка", () => {
+      withParams({ "filters[sticker]": "not-collected" });
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(siteNames(result.current.filteredData)).toEqual([
+        "Стамп само",
+        "Нищо",
+        "Празен",
+      ]);
+    });
+
+    it("returns exactly the sites offering no марка", () => {
+      withParams({ "filters[sticker]": "not-available" });
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(siteNames(result.current.filteredData)).toEqual(["Без марка"]);
+    });
+
+    // Deliberate, not a defect: a site offering no марка is reachable only
+    // through the dedicated option, so it falls out of both other views.
+    it("leaves sites offering no марка out of both collected and not-collected", () => {
+      withParams({ "filters[sticker]": "collected" });
+      const { result: collected } = renderHook(() => useSiteFilters());
+
+      withParams({ "filters[sticker]": "not-collected" });
+      const { result: notCollected } = renderHook(() => useSiteFilters());
+
+      const covered = [
+        ...siteNames(collected.current.filteredData),
+        ...siteNames(notCollected.current.filteredData),
+      ];
+
+      expect(covered).toHaveLength(4);
+      expect(covered).not.toContain("Без марка");
+    });
+
+    it("drops cities left with no matching sites", () => {
+      withParams({ "filters[sticker]": "not-available" });
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(result.current.filteredData.map((city) => city.city)).toEqual([
+        "Свищов",
+      ]);
+    });
+
+    it("offers exactly the four options", () => {
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(result.current.stickerFilters.map((o) => o.value)).toEqual([
+        "all",
+        "collected",
+        "not-collected",
+        "not-available",
+      ]);
+    });
+  });
+
+  describe("composition of the stamp and sticker filters", () => {
+    // The combination the feature exists for: the trip-planning list of sites
+    // where a марка is still achievable.
+    it("isolates stamped sites still missing a марка", () => {
+      withParams({
+        "filters[stamp]": "collected",
+        "filters[sticker]": "not-collected",
+      });
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(siteNames(result.current.filteredData)).toEqual(["Стамп само"]);
+    });
+
+    it("isolates fully collected sites", () => {
+      withParams({
+        "filters[stamp]": "collected",
+        "filters[sticker]": "collected",
+      });
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(siteNames(result.current.filteredData)).toEqual(["Пълен"]);
+    });
+
+    it("isolates unstamped sites still missing a марка", () => {
+      withParams({
+        "filters[stamp]": "not-collected",
+        "filters[sticker]": "not-collected",
+      });
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(siteNames(result.current.filteredData)).toEqual([
+        "Нищо",
+        "Празен",
+      ]);
+    });
+
+    it("returns nothing when the two filters have no overlap", () => {
+      withParams({
+        "filters[stamp]": "not-collected",
+        "filters[sticker]": "not-available",
+      });
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(result.current.filteredData).toEqual([]);
+    });
+  });
+
   describe("composition with the location filter", () => {
     it("combines a region with the stamp filter", () => {
       withParams({
@@ -139,6 +265,42 @@ describe("useSiteFilters", () => {
 
       expect(result.current.filteredData).toEqual([]);
     });
+
+    it("combines a region with the sticker filter", () => {
+      withParams({
+        "filters[location]": "Благоевградска област",
+        "filters[sticker]": "not-collected",
+      });
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(siteNames(result.current.filteredData)).toEqual([
+        "Стамп само",
+        "Нищо",
+      ]);
+    });
+
+    it("ANDs the location, stamp and sticker filters together", () => {
+      withParams({
+        "filters[location]": "Благоевградска област",
+        "filters[stamp]": "collected",
+        "filters[sticker]": "not-collected",
+      });
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(siteNames(result.current.filteredData)).toEqual(["Стамп само"]);
+    });
+
+    // Свищов holds the only site offering no марка, so the region next to it
+    // must come back empty.
+    it("returns nothing when the location excludes the sticker match", () => {
+      withParams({
+        "filters[location]": "Благоевградска област",
+        "filters[sticker]": "not-available",
+      });
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(result.current.filteredData).toEqual([]);
+    });
   });
 
   describe("query string round trip", () => {
@@ -146,22 +308,43 @@ describe("useSiteFilters", () => {
       const { result } = renderHook(() => useSiteFilters());
 
       expect(result.current.queryString).toBe(
-        "filters[location]=all&filters[stamp]=all",
+        "filters[location]=all&filters[stamp]=all&filters[sticker]=all",
       );
     });
 
-    it("reads both filters back out of the URL", () => {
+    it("reads every filter back out of the URL", () => {
       withParams({
         "filters[location]": "Банско",
         "filters[stamp]": "collected",
+        "filters[sticker]": "not-collected",
       });
       const { result } = renderHook(() => useSiteFilters());
 
       expect(result.current.selectedLocation).toBe("Банско");
       expect(result.current.stampFilter).toBe("collected");
+      expect(result.current.stickerFilter).toBe("not-collected");
       expect(result.current.queryString).toBe(
-        `filters[location]=${encodeURIComponent("Банско")}&filters[stamp]=collected`,
+        `filters[location]=${encodeURIComponent("Банско")}&filters[stamp]=collected&filters[sticker]=not-collected`,
       );
+    });
+
+    it("carries a sticker selection made after mount into the query string", () => {
+      const { result } = renderHook(() => useSiteFilters());
+
+      act(() => result.current.setStickerFilter("not-available"));
+
+      expect(result.current.stickerFilter).toBe("not-available");
+      expect(result.current.queryString).toContain(
+        "filters[sticker]=not-available",
+      );
+    });
+
+    it("falls back to the default for an unrecognised sticker value", () => {
+      withParams({ "filters[sticker]": "nonsense" });
+      const { result } = renderHook(() => useSiteFilters());
+
+      expect(result.current.stickerFilter).toBe("all");
+      expect(siteNames(result.current.filteredData)).toHaveLength(5);
     });
 
     it("carries a selection made after mount into the query string", () => {
@@ -178,7 +361,7 @@ describe("useSiteFilters", () => {
       renderHook(() => useSiteFilters());
 
       expect(pushMock).toHaveBeenCalledWith(
-        "?filters[location]=all&filters[stamp]=collected",
+        "?filters[location]=all&filters[stamp]=collected&filters[sticker]=all",
       );
     });
   });

--- a/src/hooks/useSiteFilters.ts
+++ b/src/hooks/useSiteFilters.ts
@@ -5,8 +5,11 @@ import { useRouter, useSearchParams } from "next/navigation";
 import data from "@/data/places.json";
 import {
   matchesStampFilter,
+  matchesStickerFilter,
   toStampFilterValue,
+  toStickerFilterValue,
   type StampFilterValue,
+  type StickerFilterValue,
 } from "@/lib/collectionStatus";
 
 export function useSiteFilters() {
@@ -19,6 +22,9 @@ export function useSiteFilters() {
   const initialStampFilter = toStampFilterValue(
     searchParams.get("filters[stamp]")
   );
+  const initialStickerFilter = toStickerFilterValue(
+    searchParams.get("filters[sticker]")
+  );
 
   const [selectedLocation, setSelectedLocation] =
     useState<string>(initialLocation);
@@ -30,6 +36,13 @@ export function useSiteFilters() {
   // callers stay pure wiring.
   const setStampFilter = (value: string) => {
     setStampFilterValue(toStampFilterValue(value));
+  };
+
+  const [stickerFilter, setStickerFilterValue] =
+    useState<StickerFilterValue>(initialStickerFilter);
+
+  const setStickerFilter = (value: string) => {
+    setStickerFilterValue(toStickerFilterValue(value));
   };
 
   const citiesByRegion = useMemo(() => {
@@ -58,6 +71,13 @@ export function useSiteFilters() {
     { value: "not-collected", label: "Несъбрани" },
   ];
 
+  const stickerFilters = [
+    { value: "all", label: "Всички" },
+    { value: "collected", label: "Събрани" },
+    { value: "not-collected", label: "Несъбрани" },
+    { value: "not-available", label: "Не се предлага" },
+  ];
+
   const filteredData = useMemo(
     () =>
       data
@@ -69,15 +89,17 @@ export function useSiteFilters() {
         )
         .map((city) => ({
           ...city,
-          sites: city.sites.filter((site) =>
-            matchesStampFilter(site, stampFilter)
+          sites: city.sites.filter(
+            (site) =>
+              matchesStampFilter(site, stampFilter) &&
+              matchesStickerFilter(site, stickerFilter)
           ),
         }))
         .filter((city) => city.sites.length > 0),
-    [selectedLocation, stampFilter]
+    [selectedLocation, stampFilter, stickerFilter]
   );
 
-  const queryString = `filters[location]=${encodeURIComponent(selectedLocation)}&filters[stamp]=${encodeURIComponent(stampFilter)}`;
+  const queryString = `filters[location]=${encodeURIComponent(selectedLocation)}&filters[stamp]=${encodeURIComponent(stampFilter)}&filters[sticker]=${encodeURIComponent(stickerFilter)}`;
 
   useEffect(() => {
     router.push(`?${queryString}`);
@@ -88,8 +110,11 @@ export function useSiteFilters() {
     setSelectedLocation,
     stampFilter,
     setStampFilter,
+    stickerFilter,
+    setStickerFilter,
     citiesByRegion,
     stampFilters,
+    stickerFilters,
     filteredData,
     queryString,
   };

--- a/tests/e2e/sites.spec.ts
+++ b/tests/e2e/sites.spec.ts
@@ -435,3 +435,163 @@ test.describe("Collection progress", () => {
     await expect(stickerProgress(page)).toHaveText(stickers);
   });
 });
+
+test.describe("Марка filter", () => {
+  const rows = "ul[role='list'] > li > a";
+  const stampIcons = "[data-testid='stamp-icon']";
+  const stickerIcons = "[data-testid='sticker-icon']";
+  const unavailableIcons = "[data-testid='sticker-unavailable-icon']";
+
+  test("the control offers exactly the four options", async ({ page }) => {
+    await page.goto("/sites/list");
+
+    await page.getByRole("button", { name: /^Марка:/ }).click();
+
+    for (const label of ["Всички", "Събрани", "Несъбрани", "Не се предлага"]) {
+      await expect(
+        page.getByRole("menuitem").filter({ hasText: new RegExp(`^${label}$`) }),
+      ).toBeVisible();
+    }
+    await expect(page.getByRole("menuitem")).toHaveCount(4);
+  });
+
+  test("choosing an option writes it to its own query parameter", async ({
+    page,
+  }) => {
+    await page.goto("/sites/list");
+
+    await page.getByRole("button", { name: /^Марка:/ }).click();
+    await page
+      .getByRole("menuitem")
+      .filter({ hasText: /^Събрани$/ })
+      .click();
+
+    await expect(page).toHaveURL(/filters\[sticker\]=collected/);
+    await expect(page).toHaveURL(/filters\[stamp\]=all/);
+  });
+
+  test("collected shows only sites carrying a марка", async ({ page }) => {
+    await page.goto("/sites/list?filters[sticker]=collected");
+
+    await expect(page.locator(rows).first()).toBeVisible();
+    const count = await page.locator(rows).count();
+
+    expect(count).toBeGreaterThan(0);
+    expect(await page.locator(stickerIcons).count()).toBe(count);
+    expect(await page.locator(unavailableIcons).count()).toBe(0);
+  });
+
+  test("not collected excludes both collected марки and sites offering none", async ({
+    page,
+  }) => {
+    await page.goto("/sites/list?filters[sticker]=not-collected");
+
+    await expect(page.locator(rows).first()).toBeVisible();
+
+    expect(await page.locator(rows).count()).toBeGreaterThan(0);
+    expect(await page.locator(stickerIcons).count()).toBe(0);
+    expect(await page.locator(unavailableIcons).count()).toBe(0);
+  });
+
+  test("not available returns exactly the sites offering no марка", async ({
+    page,
+  }) => {
+    await page.goto("/sites/list?filters[sticker]=not-available");
+
+    await expect(page.locator(rows).first()).toBeVisible();
+    const count = await page.locator(rows).count();
+
+    expect(await page.locator(unavailableIcons).count()).toBe(count);
+    expect(await page.locator(stickerIcons).count()).toBe(0);
+  });
+
+  // Collected plus not-collected deliberately falls short of all: the sites
+  // offering no марка sit outside both.
+  test("all shows more sites than collected and not collected together", async ({
+    page,
+  }) => {
+    await page.goto("/sites/list?filters[sticker]=all");
+    await expect(page.locator(rows).first()).toBeVisible();
+    const all = await page.locator(rows).count();
+
+    await page.goto("/sites/list?filters[sticker]=collected");
+    await expect(page.locator(rows).first()).toBeVisible();
+    const collected = await page.locator(rows).count();
+
+    await page.goto("/sites/list?filters[sticker]=not-collected");
+    await expect(page.locator(rows).first()).toBeVisible();
+    const notCollected = await page.locator(rows).count();
+
+    expect(collected + notCollected).toBeLessThan(all);
+  });
+
+  test("the stamp and sticker filters combine into the trip-planning view", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/sites/list?filters[stamp]=collected&filters[sticker]=not-collected",
+    );
+
+    await expect(page.locator(rows).first()).toBeVisible();
+    const count = await page.locator(rows).count();
+
+    expect(count).toBeGreaterThan(0);
+    expect(await page.locator(stampIcons).count()).toBe(count);
+    expect(await page.locator(stickerIcons).count()).toBe(0);
+    expect(await page.locator(unavailableIcons).count()).toBe(0);
+
+    await page.goto("/sites/list?filters[stamp]=collected");
+    await expect(page.locator(rows).first()).toBeVisible();
+    expect(await page.locator(rows).count()).toBeGreaterThan(count);
+  });
+
+  test("both filters combine with the location filter", async ({ page }) => {
+    await page.goto(
+      "/sites/list?filters[location]=Царево&filters[stamp]=collected&filters[sticker]=not-collected",
+    );
+
+    await expect(page.locator(rows).first()).toBeVisible();
+    expect(await page.locator(rows).count()).toBe(1);
+
+    await page.goto(
+      "/sites/list?filters[location]=Царево&filters[stamp]=collected&filters[sticker]=collected",
+    );
+    await expect(page.locator(rows)).toHaveCount(0);
+  });
+
+  test("the sticker selection survives switching to the map", async ({
+    page,
+  }) => {
+    await page.goto("/sites/list?filters[sticker]=not-available");
+
+    await page.getByRole("link", { name: "Карта" }).click();
+
+    await expect(page).toHaveURL(/\/sites\/map/);
+    await expect(page).toHaveURL(/filters\[sticker\]=not-available/);
+
+    await expect(page.locator("[data-pin-status]")).toHaveCount(1, {
+      timeout: 10000,
+    });
+  });
+
+  test("the controls stay reachable on a narrow viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 720 });
+    await page.goto("/sites/list");
+
+    await expect(page.getByPlaceholder("Търсене...")).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Печат:/ })).toBeVisible();
+
+    const marka = page.getByRole("button", { name: /^Марка:/ });
+    await expect(marka).toBeVisible();
+
+    const box = await marka.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.x).toBeGreaterThanOrEqual(0);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(375);
+
+    await marka.click();
+    await expect(
+      page.getByRole("menuitem").filter({ hasText: /^Не се предлага$/ }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Adds a second filter control so the collector can filter by марка independently of the печат, and combine the two.

Closes #47

## What changed

- **`useSiteFilters`** gains a `stickerFilter` state, a `setStickerFilter` that narrows through `toStickerFilterValue`, and a `stickerFilters` label list — mirroring the existing печат pattern. The selection round-trips through its own `filters[sticker]` query parameter, so it survives switching between list and map.
- **`src/app/sites/layout.tsx`** renders a `Марка` control next to `Печат`. The controls row is now `flex-wrap` with `gap-y-3` so three controls stay usable on a narrow viewport.
- **`Filter.tsx`** needed no changes.

## Semantics

The predicate lives entirely in `src/lib/collectionStatus.ts` — the hook delegates to `matchesStickerFilter` and implements no matching logic of its own. That keeps the two deliberate rules intact:

- **Not collected** means strictly `sticker === false`, excluding sites that offer no марка, so the trip-planning list only contains achievable things.
- **Collected** excludes them too, which means **collected + not collected ≠ all**. That is intended, not a defect. Sites offering no марка are reachable only through the dedicated fourth option, which doubles as the audit view.

## Tests

Unit (`src/hooks/__tests__/useSiteFilters.test.tsx`):
- each of the four options against all four site states in the fixture
- the "collected + not-collected falls short of all" invariant asserted explicitly
- stamp × sticker composition, including the motivating "печат collected, марка not collected" view
- three-way composition with the location filter
- query-string round trip for the new parameter, plus fallback for an unrecognised value

E2E (`tests/e2e/sites.spec.ts`, new `Марка filter` describe) covers the four options, both filters individually and combined, combination with the location filter, survival across a view switch, and a 375px-wide viewport check. Assertions target `data-testid` / `data-pin-status` only.

`npm test` and `npm run test:e2e` both pass — 48 e2e tests green.

## Note for reviewers

`playwright.config.ts` sets `reuseExistingServer: !CI`, so a plain `npm run test:e2e` silently runs against whatever already listens on port 3000. My first run passed nothing and looked broken for that reason; the green run above was against a fresh server on a throwaway port. Worth knowing when reviewing locally.
