### PR TITLE
feat(coins): grey pin for coins that cannot currently be collected

### DIFF
--- a/src/app/coins/map/__tests__/page.test.tsx
+++ b/src/app/coins/map/__tests__/page.test.tsx
@@ -48,6 +48,30 @@ const mockCoins = [
     location: "Велико Търново",
   },
   {
+    id: "5",
+    name: "Coin E (no longer offered)",
+    url: "https://example.com/e",
+    images: [{ url: "/img-e.jpg" }],
+    coordinates: [25.2, 43.2],
+    collected: false,
+    available: false,
+    province: "Пловдив",
+    location: "Пловдив",
+  },
+  // No coin in the shipped data is both collected and unavailable, so this
+  // combination only exists here.
+  {
+    id: "6",
+    name: "Coin F (collected, no longer offered)",
+    url: "https://example.com/f",
+    images: [{ url: "/img-f.jpg" }],
+    coordinates: [25.3, 43.3],
+    collected: true,
+    available: false,
+    province: "Пловдив",
+    location: "Пловдив",
+  },
+  {
     id: "3",
     name: "Coin C (no coordinates)",
     url: "https://example.com/c",
@@ -73,7 +97,7 @@ describe("CoinsMapPage", () => {
 
   describe("pin building", () => {
     it("builds one pin per geocoded coin, excluding coins with missing coordinates", () => {
-      expect(capturedPins).toHaveLength(3);
+      expect(capturedPins).toHaveLength(5);
     });
 
     it("keeps unique coordinates intact and spreads duplicate coordinates", () => {
@@ -94,6 +118,18 @@ describe("CoinsMapPage", () => {
     it("maps collected coins to complete and uncollected to none", () => {
       expect(capturedPins[0].status).toBe("complete");
       expect(capturedPins[1].status).toBe("none");
+    });
+
+    it("maps an uncollected coin that is no longer offered to unavailable", () => {
+      expect(capturedPins.find((pin) => pin.key === "5")?.status).toBe(
+        "unavailable",
+      );
+    });
+
+    it("keeps a collected coin complete even once it is no longer offered", () => {
+      expect(capturedPins.find((pin) => pin.key === "6")?.status).toBe(
+        "complete",
+      );
     });
 
     it("never renders a coin as partially collected", () => {

--- a/src/app/coins/map/page.tsx
+++ b/src/app/coins/map/page.tsx
@@ -4,9 +4,17 @@ import { useMemo } from "react";
 import Image from "next/image";
 import dynamic from "next/dynamic";
 import { BadgeCheckIcon } from "lucide-react";
+import { deriveCoinStatus, type CoinStatus } from "@/lib/coinStatus";
+import type { PinStatus } from "@/components/MapView";
 import { useCoinsContext } from "../context";
 
 const MapView = dynamic(() => import("@/components/MapView"), { ssr: false });
+
+const PIN_STATUS: Record<CoinStatus, PinStatus> = {
+  collected: "complete",
+  "not-collected": "none",
+  unavailable: "unavailable",
+};
 
 export default function CoinsMapPage() {
   const { filteredData } = useCoinsContext();
@@ -49,9 +57,7 @@ export default function CoinsMapPage() {
         key: coin.id,
         lat,
         lng,
-        // Coins keep their single collected flag; they have no second
-        // collectible, so they are only ever nothing or complete.
-        status: coin.collected ? ("complete" as const) : ("none" as const),
+        status: PIN_STATUS[deriveCoinStatus(coin)],
         popup: (
           <div>
             <Image

--- a/src/app/sites/map/page.tsx
+++ b/src/app/sites/map/page.tsx
@@ -5,10 +5,17 @@ import Image from "next/image";
 import dynamic from "next/dynamic";
 import { randomId } from "@/utils";
 import { CollectionIcons } from "@/components/CollectionIcons";
-import { deriveStatus } from "@/lib/collectionStatus";
+import { deriveStatus, type CollectionStatus } from "@/lib/collectionStatus";
+import type { PinStatus } from "@/components/MapView";
 import { useSitesContext } from "../context";
 
 const MapView = dynamic(() => import("@/components/MapView"), { ssr: false });
+
+const PIN_STATUS: Record<CollectionStatus, PinStatus> = {
+  none: "none",
+  partial: "partial",
+  complete: "complete",
+};
 
 export default function SitesMapPage() {
   const { filteredData } = useSitesContext();
@@ -20,7 +27,7 @@ export default function SitesMapPage() {
           key: `${city.city}-${site.name}-${randomId()}`,
           lat: site.lat,
           lng: site.lng,
-          status: deriveStatus(site),
+          status: PIN_STATUS[deriveStatus(site)],
           popup: (
             <div>
               <div className="relative w-full h-24 mb-2">

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -5,13 +5,17 @@ import { FullScreen } from "leaflet.fullscreen";
 import L from "leaflet";
 import { useEffect } from "react";
 import type { ReactNode } from "react";
-import type { CollectionStatus } from "@/lib/collectionStatus";
+
+/** Each view translates its own domain status into this rather than the map
+ *  borrowing a domain type, so a coin-only colour does not force a dead
+ *  branch into the sites domain. */
+export type PinStatus = "none" | "partial" | "complete" | "unavailable";
 
 export type MapPin = {
   key: string;
   lat: number;
   lng: number;
-  status: CollectionStatus;
+  status: PinStatus;
   popup: ReactNode;
 };
 
@@ -22,13 +26,14 @@ interface MapViewProps {
   height?: string;
 }
 
-const STATUS_COLOURS: Record<CollectionStatus, string> = {
+const STATUS_COLOURS: Record<PinStatus, string> = {
   none: "#228cc5",
   partial: "#f59e0b",
   complete: "#22c55e",
+  unavailable: "#9ca3af",
 };
 
-function statusIcon(status: CollectionStatus) {
+function statusIcon(status: PinStatus) {
   return L.divIcon({
     className: "",
     // The status is carried as a data attribute so tests can target meaning
@@ -40,10 +45,11 @@ function statusIcon(status: CollectionStatus) {
   });
 }
 
-const statusIcons: Record<CollectionStatus, ReturnType<typeof statusIcon>> = {
+const statusIcons: Record<PinStatus, ReturnType<typeof statusIcon>> = {
   none: statusIcon("none"),
   partial: statusIcon("partial"),
   complete: statusIcon("complete"),
+  unavailable: statusIcon("unavailable"),
 };
 
 function FitBounds({ pins }: { pins: MapPin[] }) {

--- a/src/components/__tests__/MapView.test.tsx
+++ b/src/components/__tests__/MapView.test.tsx
@@ -70,11 +70,12 @@ describe("MapView", () => {
     expect(screen.getAllByTestId("marker")).toHaveLength(3);
   });
 
-  it("publishes each of the three statuses on its marker", () => {
+  it("publishes each pin status on its marker", () => {
     const pins = [
       makePin({ key: "none", status: "none" }),
       makePin({ key: "partial", status: "partial" }),
       makePin({ key: "complete", status: "complete" }),
+      makePin({ key: "unavailable", status: "unavailable" }),
     ];
     render(<MapView pins={pins} />);
 
@@ -82,7 +83,7 @@ describe("MapView", () => {
       .getAllByTestId("marker")
       .map((m) => m.getAttribute("data-pin-status"));
 
-    expect(statuses).toEqual(["none", "partial", "complete"]);
+    expect(statuses).toEqual(["none", "partial", "complete", "unavailable"]);
   });
 
 

--- a/src/lib/__tests__/coinStatus.test.ts
+++ b/src/lib/__tests__/coinStatus.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  coinIsUnavailable,
+  deriveCoinStatus,
+  type CoinState,
+  type CoinStatus,
+} from "@/lib/coinStatus";
+
+const state = (collected: boolean, available: boolean): CoinState => ({
+  collected,
+  available,
+});
+
+/** Every legal coin state: collected (2) x available (2). */
+const ALL_STATES: { label: string; state: CoinState }[] = [
+  { label: "not collected, available", state: state(false, true) },
+  { label: "not collected, unavailable", state: state(false, false) },
+  { label: "collected, available", state: state(true, true) },
+  { label: "collected, unavailable", state: state(true, false) },
+];
+
+describe("deriveCoinStatus", () => {
+  const expected: [CoinState, CoinStatus][] = [
+    [state(false, true), "not-collected"],
+    [state(false, false), "unavailable"],
+    [state(true, true), "collected"],
+    [state(true, false), "collected"],
+  ];
+
+  it.each(expected)("derives %o as %s", (input, status) => {
+    expect(deriveCoinStatus(input)).toBe(status);
+  });
+
+  // Zero coins are in this state in the shipped data, so the unit test is the
+  // only place the rule is exercised.
+  it("keeps a collected coin collected once it stops being offered", () => {
+    expect(deriveCoinStatus(state(true, false))).toBe("collected");
+  });
+
+  it("covers every coin state", () => {
+    expect(expected).toHaveLength(ALL_STATES.length);
+  });
+});
+
+describe("coinIsUnavailable", () => {
+  const expected: [CoinState, boolean][] = [
+    [state(false, true), false],
+    [state(false, false), true],
+    [state(true, true), false],
+    [state(true, false), true],
+  ];
+
+  it.each(expected)("reads %o as %s", (input, unavailable) => {
+    expect(coinIsUnavailable(input)).toBe(unavailable);
+  });
+
+  it("is independent of collection, so a collected coin can still be unavailable", () => {
+    expect(coinIsUnavailable(state(true, false))).toBe(true);
+    expect(deriveCoinStatus(state(true, false))).toBe("collected");
+  });
+
+  it("covers every coin state", () => {
+    expect(expected).toHaveLength(ALL_STATES.length);
+  });
+});

--- a/src/lib/coinStatus.ts
+++ b/src/lib/coinStatus.ts
@@ -1,0 +1,27 @@
+/**
+ * `available` is a present-tense stock fact that may reverse. Despite sharing
+ * the label "не се предлага" with a site's `null` марка, it is not the same
+ * concept: the марка case is permanent, this one is a snapshot.
+ */
+
+export type CoinState = {
+  collected: boolean;
+  available: boolean;
+};
+
+export type CoinStatus = "collected" | "not-collected" | "unavailable";
+
+export function coinIsUnavailable(state: CoinState): boolean {
+  return !state.available;
+}
+
+/** Collected wins over unavailable: a single display slot must choose, and
+ *  owning the coin is the more useful signal. The availability text is driven
+ *  by `coinIsUnavailable` instead, so both facts still reach the collector. */
+export function deriveCoinStatus(state: CoinState): CoinStatus {
+  if (state.collected) {
+    return "collected";
+  }
+
+  return coinIsUnavailable(state) ? "unavailable" : "not-collected";
+}


### PR DESCRIPTION
Closes #60. First slice of the coin availability PRD (#59).

## What changed

Coins that cannot currently be collected render as a distinct grey pin on the coins map instead of looking identical to coins that are simply not yet collected. Only the pin colour is in scope — the written message, the filter and the collected-and-unavailable presentation are the later slices.

- **`src/lib/coinStatus.ts`** — new pure, framework-free module owning the coin state shape, the derived status (`collected` | `not-collected` | `unavailable`) and the availability predicate, mirroring `collectionStatus` for печати and марки. No imports from components.
- **`MapView`** — introduces `PinStatus` as the map's own presentation vocabulary (the three existing states plus `unavailable`, grey `#9ca3af`) and stops importing `CollectionStatus` from the sites domain.
- **Both map views translate into it.** Identity mapping for sites, so nothing the collector sees changes there. For coins, `collected → complete`, so a collected coin stays green regardless of availability — the pin has one slot and the more useful signal wins.

## Verification

Checked against the running app, not only the tests: the coins map publishes `{complete: 25, none: 130, unavailable: 5}`, and the 5 grey pins are the expected coins (Роженски манастир, РИМ Шумен, РИМ Пловдив, Дом на хумора и сатирата, Рилски манастир).

- Unit tests enumerate all four combinations of collected × available, following the table pattern in the existing collection status tests.
- The `MapView` test asserts `data-pin-status="unavailable"` — the attribute, not the colour.
- The coins map page test gains an unavailable coin and a collected-and-unavailable coin. No coin in the shipped data is in that second state, so the fixture is the only place it exists.
- 133 unit tests, 52 e2e, `tsc --noEmit` and `eslint` all pass.

## Note

The PRD quotes 29 collected coins; the data currently has 25. The 5 unavailable coins match.