### PR TITLE
feat(coins): explain why a coin cannot currently be collected

### DIFF
--- a/src/app/coins/list/page.tsx
+++ b/src/app/coins/list/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { BadgeCheckIcon } from "lucide-react";
+import { CoinAvailability } from "@/components/CoinAvailability";
 import { useCoinsContext } from "../context";
 
 export default function CoinsListPage() {
@@ -46,6 +47,7 @@ export default function CoinsListPage() {
                 />
               </div>
             )}
+            <CoinAvailability state={coin} className="mt-3" />
           </div>
         </li>
       ))}

--- a/src/app/coins/map/__tests__/page.test.tsx
+++ b/src/app/coins/map/__tests__/page.test.tsx
@@ -167,5 +167,29 @@ describe("CoinsMapPage", () => {
       );
       expect(queryByText("Събрана")).not.toBeInTheDocument();
     });
+
+    it("explains why a coin that is no longer offered looks different", () => {
+      const pin = capturedPins.find((p) => p.key === "5")!;
+      const { getByTestId } = render(pin.popup as React.ReactElement);
+
+      expect(getByTestId("unavailable-badge")).toHaveTextContent(
+        "В момента не се предлага",
+      );
+    });
+
+    it("keeps the product link usable on a coin that is no longer offered", () => {
+      const pin = capturedPins.find((p) => p.key === "5")!;
+      const { getByRole } = render(pin.popup as React.ReactElement);
+
+      expect(getByRole("link")).toHaveAttribute("href", "https://example.com/e");
+    });
+
+    it("says nothing about availability for a coin that can still be collected", () => {
+      const { queryByTestId } = render(
+        capturedPins[1].popup as React.ReactElement,
+      );
+
+      expect(queryByTestId("unavailable-badge")).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/app/coins/map/page.tsx
+++ b/src/app/coins/map/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import dynamic from "next/dynamic";
 import { BadgeCheckIcon } from "lucide-react";
 import { deriveCoinStatus, type CoinStatus } from "@/lib/coinStatus";
+import { CoinAvailability } from "@/components/CoinAvailability";
 import type { PinStatus } from "@/components/MapView";
 import { useCoinsContext } from "../context";
 
@@ -77,6 +78,7 @@ export default function CoinsMapPage() {
                 <span className="text-xs text-green-700">Събрана</span>
               </div>
             )}
+            <CoinAvailability state={coin} className="mt-1" />
             <a
               href={coin.url}
               target="_blank"

--- a/src/components/CoinAvailability.tsx
+++ b/src/components/CoinAvailability.tsx
@@ -18,10 +18,8 @@ export const CoinAvailability = ({
   state,
   className,
 }: CoinAvailabilityProps) => {
-  // Availability is read on its own axis rather than through the pin's
-  // collapsed status, so revisiting which colour wins cannot silently change
-  // what the text says. The collected gate is this slice only — #63 drops it
-  // so an owned coin shows both facts.
+  // The collected gate is this slice only — #63 drops it so an owned coin
+  // shows both facts.
   if (state.collected || !coinIsUnavailable(state)) {
     return null;
   }

--- a/src/components/CoinAvailability.tsx
+++ b/src/components/CoinAvailability.tsx
@@ -18,8 +18,6 @@ export const CoinAvailability = ({
   state,
   className,
 }: CoinAvailabilityProps) => {
-  // The collected gate is this slice only — #63 drops it so an owned coin
-  // shows both facts.
   if (state.collected || !coinIsUnavailable(state)) {
     return null;
   }

--- a/src/components/CoinAvailability.tsx
+++ b/src/components/CoinAvailability.tsx
@@ -1,0 +1,34 @@
+import { CircleSlashIcon } from "lucide-react";
+
+import { deriveCoinStatus, type CoinState } from "@/lib/coinStatus";
+
+/**
+ * "в момента" is load-bearing: a coin can start being offered again, and the
+ * collector should re-check rather than write it off. The filter option says
+ * the shorter "Не се предлага" because it sits among other short labels.
+ */
+const MESSAGE = "В момента не се предлага";
+
+interface CoinAvailabilityProps {
+  state: CoinState;
+  className?: string;
+}
+
+export const CoinAvailability = ({
+  state,
+  className,
+}: CoinAvailabilityProps) => {
+  if (deriveCoinStatus(state) !== "unavailable") {
+    return null;
+  }
+
+  return (
+    <span
+      data-testid="unavailable-badge"
+      className={`flex items-center justify-center gap-1 text-gray-500 ${className ?? ""}`}
+    >
+      <CircleSlashIcon aria-hidden="true" className="w-4 h-4 shrink-0" />
+      <span className="text-xs">{MESSAGE}</span>
+    </span>
+  );
+};

--- a/src/components/CoinAvailability.tsx
+++ b/src/components/CoinAvailability.tsx
@@ -1,6 +1,6 @@
 import { CircleSlashIcon } from "lucide-react";
 
-import { deriveCoinStatus, type CoinState } from "@/lib/coinStatus";
+import { coinIsUnavailable, type CoinState } from "@/lib/coinStatus";
 
 /**
  * "в момента" is load-bearing: a coin can start being offered again, and the
@@ -18,7 +18,11 @@ export const CoinAvailability = ({
   state,
   className,
 }: CoinAvailabilityProps) => {
-  if (deriveCoinStatus(state) !== "unavailable") {
+  // Availability is read on its own axis rather than through the pin's
+  // collapsed status, so revisiting which colour wins cannot silently change
+  // what the text says. The collected gate is this slice only — #63 drops it
+  // so an owned coin shows both facts.
+  if (state.collected || !coinIsUnavailable(state)) {
     return null;
   }
 

--- a/src/components/__tests__/CoinAvailability.test.tsx
+++ b/src/components/__tests__/CoinAvailability.test.tsx
@@ -30,8 +30,8 @@ describe("CoinAvailability", () => {
     expect(screen.queryByTestId("unavailable-badge")).toBeNull();
   });
 
-  // The collected-and-unavailable case is a later slice; until then a collected
-  // coin stays silent, matching what the pin already does.
+  // Deliberate, not an oversight: a collected coin says nothing about
+  // availability, matching the pin, which also lets collected win.
   it("stays silent on a collected coin that is no longer offered", () => {
     render(<CoinAvailability state={state(true, false)} />);
 

--- a/src/components/__tests__/CoinAvailability.test.tsx
+++ b/src/components/__tests__/CoinAvailability.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { CoinAvailability } from "@/components/CoinAvailability";
+import type { CoinState } from "@/lib/coinStatus";
+
+const state = (collected: boolean, available: boolean): CoinState => ({
+  collected,
+  available,
+});
+
+const MESSAGE = "В момента не се предлага";
+
+describe("CoinAvailability", () => {
+  it("tells an uncollected coin that is no longer offered why it differs", () => {
+    render(<CoinAvailability state={state(false, false)} />);
+
+    expect(screen.getByTestId("unavailable-badge")).toBeInTheDocument();
+    expect(screen.getByText(MESSAGE)).toBeInTheDocument();
+  });
+
+  it("says nothing about a coin that can still be collected", () => {
+    render(<CoinAvailability state={state(false, true)} />);
+
+    expect(screen.queryByTestId("unavailable-badge")).toBeNull();
+  });
+
+  it("says nothing about a collected coin", () => {
+    render(<CoinAvailability state={state(true, true)} />);
+
+    expect(screen.queryByTestId("unavailable-badge")).toBeNull();
+  });
+
+  // The collected-and-unavailable case is a later slice; until then a collected
+  // coin stays silent, matching what the pin already does.
+  it("stays silent on a collected coin that is no longer offered", () => {
+    render(<CoinAvailability state={state(true, false)} />);
+
+    expect(screen.queryByTestId("unavailable-badge")).toBeNull();
+  });
+
+  it("keeps the temporal qualifier, so the collector re-checks rather than gives up", () => {
+    render(<CoinAvailability state={state(false, false)} />);
+
+    expect(screen.getByTestId("unavailable-badge").textContent).toContain(
+      "В момента",
+    );
+  });
+});

--- a/tests/e2e/coins.spec.ts
+++ b/tests/e2e/coins.spec.ts
@@ -118,6 +118,59 @@ test.describe("Coins views", () => {
     await expect(badges).toHaveCount(filteredCount);
   });
 
+  test("coins that cannot currently be collected explain why in the list", async ({
+    page,
+  }) => {
+    await page.goto("/coins/list");
+    await expect(page.locator("ul[role='list'] li").first()).toBeVisible({
+      timeout: 10000,
+    });
+
+    const badges = page.locator("[data-testid='unavailable-badge']");
+
+    await expect(badges.first()).toBeVisible();
+    await expect(badges.first()).toHaveText("В момента не се предлага");
+  });
+
+  test("a card that cannot be collected keeps its image and outbound link", async ({
+    page,
+  }) => {
+    await page.goto("/coins/list");
+    await expect(page.locator("ul[role='list'] li").first()).toBeVisible({
+      timeout: 10000,
+    });
+
+    const card = page
+      .locator("ul[role='list'] li")
+      .filter({ has: page.locator("[data-testid='unavailable-badge']") })
+      .first();
+
+    await expect(card.locator("img")).toBeVisible();
+    await expect(card.getByRole("link")).toHaveAttribute("href", /.+/);
+  });
+
+  test("the map popup carries the same availability message as the list", async ({
+    page,
+  }) => {
+    // Габрово holds exactly one coin (Дом на хумора и сатирата) and it is
+    // unavailable, so filtering by location leaves a single pin to click.
+    await page.goto(
+      `/coins/map?filters[location]=${encodeURIComponent("Габрово")}&filters[collected]=all`,
+    );
+
+    await expect(page.locator(".leaflet-container")).toBeVisible({
+      timeout: 10000,
+    });
+    const pin = page.locator('[data-pin-status="unavailable"]').first();
+    await expect(pin).toBeVisible({ timeout: 10000 });
+
+    await pin.click({ force: true });
+
+    await expect(
+      page.locator(".leaflet-popup").getByTestId("unavailable-badge"),
+    ).toHaveText("В момента не се предлага");
+  });
+
   test("'Монети' nav link is active on /coins/list", async ({ page }) => {
     await page.goto("/coins/list");
     const link = page.getByRole("link", { name: "Монети" });

--- a/tests/e2e/coins.spec.ts
+++ b/tests/e2e/coins.spec.ts
@@ -152,8 +152,8 @@ test.describe("Coins views", () => {
   test("the map popup carries the same availability message as the list", async ({
     page,
   }) => {
-    // Габрово holds exactly one coin (Дом на хумора и сатирата) and it is
-    // unavailable, so filtering by location leaves a single pin to click.
+    // Filtered to a single-coin location: on the full map the pins overlap and
+    // a forced click lands on a neighbour's popup.
     await page.goto(
       `/coins/map?filters[location]=${encodeURIComponent("Габрово")}&filters[collected]=all`,
     );


### PR DESCRIPTION
Closes #61. Second slice of the coin availability PRD (#59), on top of #64.

## What changed

A coin that cannot currently be collected now carries the line **"В момента не се предлага"**, so the collector reads the reason instead of inferring it from a colour.

- **`src/components/CoinAvailability.tsx`** — a shared badge used by both the coins list card and the map popup, following the `CollectionIcons` precedent of one component serving both views. That is what guarantees the two views agree on which coins carry the message.
- The badge is driven by `coinIsUnavailable`, **not** by `deriveCoinStatus`. The latter collapses collected+unavailable to `collected` for the pin's single slot; the badge is a different slot with a different rule — the PRD's "pin colour collapses; text does not". Coupling them would let a pin-motivated change to the collapse rule silently move the text.
- An explicit `state.collected` gate scopes this slice to uncollected coins. The collected-and-unavailable case is #63, which removes that clause.
- Grey icon plus text, in the same slot as the green collected badge. The card is **not** dimmed and the image and outbound link stay fully usable.

The badge keeps the temporal "в момента" while the filter option (next slice) keeps the shorter "Не се предлага" — availability can reverse, and the collector should re-check rather than write the coin off.

## Verification

Looked at it rendered in both views, not only asserted: the badge sits under the coin name in grey with the thumbnail undimmed, and the popup shows the same line above a working "Виж монетата" link.

- Component tests cover all four collected × available combinations, including the deliberate silence on collected-and-unavailable in this slice.
- Map page tests assert the popup message and that the product link still works.
- Three new e2e tests reach the badge via `data-testid='unavailable-badge'`, never via colour. The list tests run against the default view so they hold as long as any coin is unavailable; the popup test filters to a single-coin location because on the full map the pins overlap and a click lands on a neighbour's popup (verified — it fails without the filter).
- 143 unit tests, 55 e2e, `tsc --noEmit` and `eslint` all pass.