### PR TITLE
feat(coins): filter by availability and keep "Не" to what can be collected

### DIFF
--- a/src/hooks/__tests__/useCoinsFilters.test.tsx
+++ b/src/hooks/__tests__/useCoinsFilters.test.tsx
@@ -58,6 +58,30 @@ vi.mock("@/data/coins.json", () => ({
       province: "София",
       location: "София",
     },
+    {
+      id: "5",
+      name: "Coin E",
+      url: "https://example.com/e",
+      images: [{ url: "img-e" }],
+      coordinates: [23.5, 42.9],
+      collected: false,
+      available: false,
+      province: "София",
+      location: "София",
+    },
+    // No coin in the shipped data is both collected and unavailable; the
+    // fixture carries one so the independence of the two axes is exercised.
+    {
+      id: "6",
+      name: "Coin F",
+      url: "https://example.com/f",
+      images: [{ url: "img-f" }],
+      coordinates: [25.2, 43.2],
+      collected: true,
+      available: false,
+      province: "Велико Търново",
+      location: "Свищов",
+    },
   ],
 }));
 
@@ -77,7 +101,7 @@ describe("useCoinsFilters", () => {
   it("returns all coins when no filters are applied", () => {
     const { result } = renderHook(() => useCoinsFilters());
 
-    expect(result.current.filteredData).toHaveLength(4);
+    expect(result.current.filteredData).toHaveLength(6);
     expect(result.current.selectedLocation).toBe("all");
     expect(result.current.collectedFilter).toBe("all");
   });
@@ -86,35 +110,80 @@ describe("useCoinsFilters", () => {
     setSearch("filters[location]=София");
     const { result } = renderHook(() => useCoinsFilters());
 
-    expect(result.current.filteredData.map((c) => c.id)).toEqual(["3", "4"]);
+    expect(result.current.filteredData.map((c) => c.id)).toEqual([
+      "3",
+      "4",
+      "5",
+    ]);
   });
 
   it("filters by city (location field)", () => {
     setSearch("filters[location]=Свищов");
     const { result } = renderHook(() => useCoinsFilters());
 
-    expect(result.current.filteredData.map((c) => c.id)).toEqual(["2"]);
+    expect(result.current.filteredData.map((c) => c.id)).toEqual(["2", "6"]);
   });
 
-  it("filters by collected=yes", () => {
-    setSearch("filters[collected]=yes");
+  it("filters by collected", () => {
+    setSearch("filters[collected]=collected");
     const { result } = renderHook(() => useCoinsFilters());
 
-    expect(result.current.filteredData.map((c) => c.id)).toEqual(["1", "3"]);
+    expect(result.current.filteredData.map((c) => c.id)).toEqual([
+      "1",
+      "3",
+      "6",
+    ]);
   });
 
-  it("filters by collected=no", () => {
-    setSearch("filters[collected]=no");
+  it("leaves coins that cannot be obtained out of the not-collected list", () => {
+    setSearch("filters[collected]=not-collected");
     const { result } = renderHook(() => useCoinsFilters());
 
     expect(result.current.filteredData.map((c) => c.id)).toEqual(["2", "4"]);
   });
 
+  it("filters by not-available regardless of whether the coin is collected", () => {
+    setSearch("filters[collected]=not-available");
+    const { result } = renderHook(() => useCoinsFilters());
+
+    expect(result.current.filteredData.map((c) => c.id)).toEqual(["5", "6"]);
+  });
+
+  it("falls back to all for a link bookmarked with the old yes value", () => {
+    setSearch("filters[collected]=yes");
+    const { result } = renderHook(() => useCoinsFilters());
+
+    expect(result.current.collectedFilter).toBe("all");
+    expect(result.current.filteredData).toHaveLength(6);
+  });
+
+  it("falls back to all for an unrecognised value", () => {
+    setSearch("filters[collected]=nonsense");
+    const { result } = renderHook(() => useCoinsFilters());
+
+    expect(result.current.collectedFilter).toBe("all");
+    expect(result.current.filteredData).toHaveLength(6);
+  });
+
   it("combines location and collected filters", () => {
-    setSearch("filters[location]=София&filters[collected]=yes");
+    setSearch("filters[location]=София&filters[collected]=collected");
     const { result } = renderHook(() => useCoinsFilters());
 
     expect(result.current.filteredData.map((c) => c.id)).toEqual(["3"]);
+  });
+
+  it("composes the location filter with the availability narrowing", () => {
+    setSearch("filters[location]=София&filters[collected]=not-collected");
+    const { result } = renderHook(() => useCoinsFilters());
+
+    expect(result.current.filteredData.map((c) => c.id)).toEqual(["4"]);
+  });
+
+  it("composes the location filter with not-available", () => {
+    setSearch("filters[location]=София&filters[collected]=not-available");
+    const { result } = renderHook(() => useCoinsFilters());
+
+    expect(result.current.filteredData.map((c) => c.id)).toEqual(["5"]);
   });
 
   it("builds locationsByProvince grouped by province with nested cities", () => {
@@ -142,17 +211,18 @@ describe("useCoinsFilters", () => {
 
     expect(result.current.collectedFilters).toEqual([
       { value: "all", label: "Всички" },
-      { value: "yes", label: "Да" },
-      { value: "no", label: "Не" },
+      { value: "collected", label: "Да" },
+      { value: "not-collected", label: "Не" },
+      { value: "not-available", label: "Не се предлага" },
     ]);
   });
 
   it("encodes the active filters into queryString", () => {
-    setSearch("filters[location]=София&filters[collected]=yes");
+    setSearch("filters[location]=София&filters[collected]=collected");
     const { result } = renderHook(() => useCoinsFilters());
 
     expect(result.current.queryString).toBe(
-      `filters[location]=${encodeURIComponent("София")}&filters[collected]=yes`,
+      `filters[location]=${encodeURIComponent("София")}&filters[collected]=collected`,
     );
   });
 
@@ -175,10 +245,10 @@ describe("useCoinsFilters", () => {
   it("calls router.replace when setCollectedFilter is called", () => {
     const { result } = renderHook(() => useCoinsFilters());
 
-    result.current.setCollectedFilter("yes");
+    result.current.setCollectedFilter("not-available");
 
     expect(replaceMock).toHaveBeenCalledWith(
-      `?filters[location]=all&filters[collected]=yes`,
+      `?filters[location]=all&filters[collected]=not-available`,
     );
   });
 
@@ -188,10 +258,10 @@ describe("useCoinsFilters", () => {
     expect(result.current.selectedLocation).toBe("all");
     expect(result.current.collectedFilter).toBe("all");
 
-    setSearch("filters[location]=София&filters[collected]=yes");
+    setSearch("filters[location]=София&filters[collected]=collected");
     rerender();
 
     expect(result.current.selectedLocation).toBe("София");
-    expect(result.current.collectedFilter).toBe("yes");
+    expect(result.current.collectedFilter).toBe("collected");
   });
 });

--- a/src/hooks/__tests__/useCoinsFilters.test.tsx
+++ b/src/hooks/__tests__/useCoinsFilters.test.tsx
@@ -252,6 +252,16 @@ describe("useCoinsFilters", () => {
     );
   });
 
+  it("normalises an unsupported value instead of writing it to the URL", () => {
+    const { result } = renderHook(() => useCoinsFilters());
+
+    result.current.setCollectedFilter("yes");
+
+    expect(replaceMock).toHaveBeenCalledWith(
+      `?filters[location]=all&filters[collected]=all`,
+    );
+  });
+
   it("reflects updated URL params on re-render (back/forward navigation)", () => {
     const { result, rerender } = renderHook(() => useCoinsFilters());
 

--- a/src/hooks/useCoinsFilters.ts
+++ b/src/hooks/useCoinsFilters.ts
@@ -22,9 +22,11 @@ export function useCoinsFilters() {
     );
   };
 
+  // The filter widget deals in plain strings; narrowing happens here so the URL
+  // can never disagree with the filter actually applied.
   const setCollectedFilter = (value: string) => {
     router.replace(
-      `?filters[location]=${encodeURIComponent(selectedLocation)}&filters[collected]=${encodeURIComponent(value)}`,
+      `?filters[location]=${encodeURIComponent(selectedLocation)}&filters[collected]=${toCoinFilterValue(value)}`,
     );
   };
 

--- a/src/hooks/useCoinsFilters.ts
+++ b/src/hooks/useCoinsFilters.ts
@@ -3,13 +3,18 @@
 import { useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import coins from "@/data/coins.json";
+import { matchesCoinFilter, toCoinFilterValue } from "@/lib/coinStatus";
 
 export function useCoinsFilters() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
   const selectedLocation = searchParams.get("filters[location]") || "all";
-  const collectedFilter = searchParams.get("filters[collected]") || "all";
+  // Links bookmarked with the old yes/no values fall back to "all" rather than
+  // being aliased; mixing them with not-available would be an incoherent set.
+  const collectedFilter = toCoinFilterValue(
+    searchParams.get("filters[collected]"),
+  );
 
   const setSelectedLocation = (value: string) => {
     router.replace(
@@ -56,8 +61,9 @@ export function useCoinsFilters() {
 
   const collectedFilters = [
     { value: "all", label: "Всички" },
-    { value: "yes", label: "Да" },
-    { value: "no", label: "Не" },
+    { value: "collected", label: "Да" },
+    { value: "not-collected", label: "Не" },
+    { value: "not-available", label: "Не се предлага" },
   ];
 
   const filteredData = useMemo(
@@ -68,15 +74,7 @@ export function useCoinsFilters() {
           coin.province === selectedLocation ||
           coin.location === selectedLocation;
 
-        let passesCollected = true;
-
-        if (collectedFilter === "yes") {
-          passesCollected = coin.collected === true;
-        } else if (collectedFilter === "no") {
-          passesCollected = coin.collected === false;
-        }
-
-        return passesLocation && passesCollected;
+        return passesLocation && matchesCoinFilter(coin, collectedFilter);
       }),
     [selectedLocation, collectedFilter],
   );

--- a/src/lib/__tests__/coinStatus.test.ts
+++ b/src/lib/__tests__/coinStatus.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect } from "vitest";
 import {
   coinIsUnavailable,
   deriveCoinStatus,
+  matchesCoinFilter,
+  toCoinFilterValue,
+  COIN_FILTER_VALUES,
+  type CoinFilterValue,
   type CoinState,
   type CoinStatus,
 } from "@/lib/coinStatus";
@@ -40,6 +44,57 @@ describe("deriveCoinStatus", () => {
   it("covers every coin state", () => {
     expect(expected).toHaveLength(ALL_STATES.length);
   });
+});
+
+describe("matchesCoinFilter", () => {
+  const matrix: [CoinFilterValue, boolean[]][] = [
+    // order follows ALL_STATES
+    ["all", [true, true, true, true]],
+    ["collected", [false, false, true, true]],
+    ["not-collected", [true, false, false, false]],
+    ["not-available", [false, true, false, true]],
+  ];
+
+  it.each(matrix)(
+    "filter %s matches the expected states",
+    (filter, expected) => {
+      const actual = ALL_STATES.map((s) => matchesCoinFilter(s.state, filter));
+      expect(actual).toEqual(expected);
+    },
+  );
+
+  it("keeps the trip-planning list to coins that can actually be collected", () => {
+    expect(matchesCoinFilter(state(false, false), "not-collected")).toBe(false);
+    expect(matchesCoinFilter(state(false, true), "not-collected")).toBe(true);
+  });
+
+  it("answers on availability regardless of collection", () => {
+    expect(matchesCoinFilter(state(true, false), "not-available")).toBe(true);
+    expect(matchesCoinFilter(state(false, false), "not-available")).toBe(true);
+  });
+
+  it("keeps an owned coin collected once it stops being offered", () => {
+    expect(matchesCoinFilter(state(true, false), "collected")).toBe(true);
+  });
+
+  it("covers every filter value", () => {
+    expect(matrix.map(([filter]) => filter)).toEqual([...COIN_FILTER_VALUES]);
+  });
+});
+
+describe("toCoinFilterValue", () => {
+  it.each([...COIN_FILTER_VALUES])("accepts %s unchanged", (value) => {
+    expect(toCoinFilterValue(value)).toBe(value);
+  });
+
+  // The values were renamed from yes/no when not-available joined the set, so
+  // links bookmarked before that fall back rather than resolving wrongly.
+  it.each(["yes", "no", "", "nonsense", null])(
+    "falls back to all for %s",
+    (value) => {
+      expect(toCoinFilterValue(value)).toBe("all");
+    },
+  );
 });
 
 describe("coinIsUnavailable", () => {

--- a/src/lib/coinStatus.ts
+++ b/src/lib/coinStatus.ts
@@ -11,8 +11,43 @@ export type CoinState = {
 
 export type CoinStatus = "collected" | "not-collected" | "unavailable";
 
+export const COIN_FILTER_VALUES = [
+  "all",
+  "collected",
+  "not-collected",
+  "not-available",
+] as const;
+
+export type CoinFilterValue = (typeof COIN_FILTER_VALUES)[number];
+
+export function toCoinFilterValue(value: string | null): CoinFilterValue {
+  return COIN_FILTER_VALUES.includes(value as CoinFilterValue)
+    ? (value as CoinFilterValue)
+    : "all";
+}
+
 export function coinIsUnavailable(state: CoinState): boolean {
   return !state.available;
+}
+
+export function matchesCoinFilter(
+  state: CoinState,
+  filter: CoinFilterValue,
+): boolean {
+  switch (filter) {
+    case "collected":
+      return state.collected;
+    // Coins that cannot be obtained are excluded deliberately: this is the
+    // trip-planning list, and it must only contain achievable things.
+    case "not-collected":
+      return !state.collected && !coinIsUnavailable(state);
+    // Availability is read on its own axis, so an owned coin that is no longer
+    // offered still answers this filter.
+    case "not-available":
+      return coinIsUnavailable(state);
+    default:
+      return true;
+  }
 }
 
 /** Collected wins over unavailable: a single display slot must choose, and

--- a/tests/e2e/coins.spec.ts
+++ b/tests/e2e/coins.spec.ts
@@ -169,28 +169,6 @@ test.describe("Coins views", () => {
     );
   });
 
-  test("'Не' and 'Не се предлага' together account for every uncollected coin", async ({
-    page,
-  }) => {
-    const countFor = async (filter: string) => {
-      await page.goto(
-        `/coins/list?filters[location]=all&filters[collected]=${filter}`,
-      );
-      await expect(page.locator("ul[role='list'] li").first()).toBeVisible({
-        timeout: 10000,
-      });
-      return page.locator("ul[role='list'] li").count();
-    };
-
-    const all = await countFor("all");
-    const collected = await countFor("collected");
-    const notCollected = await countFor("not-collected");
-    const notAvailable = await countFor("not-available");
-
-    expect(notCollected).toBeLessThan(all - collected);
-    expect(notCollected + notAvailable).toBe(all - collected);
-  });
-
   test("a link bookmarked with the old yes value falls back to showing every coin", async ({
     page,
   }) => {

--- a/tests/e2e/coins.spec.ts
+++ b/tests/e2e/coins.spec.ts
@@ -108,7 +108,7 @@ test.describe("Coins views", () => {
       .click();
     await page.locator('[role="menuitem"]').filter({ hasText: "Да" }).click();
 
-    await expect(page).toHaveURL(/filters\[collected\]=yes/);
+    await expect(page).toHaveURL(/filters\[collected\]=collected/);
 
     const cards = page.locator("ul[role='list'] li");
     const filteredCount = await cards.count();
@@ -116,6 +116,96 @@ test.describe("Coins views", () => {
 
     const badges = page.locator("[data-testid='collected-badge']");
     await expect(badges).toHaveCount(filteredCount);
+  });
+
+  test("the collected control offers exactly the four options", async ({
+    page,
+  }) => {
+    await page.goto("/coins/list");
+
+    await page.getByRole("button", { name: /^Събрани:/ }).click();
+
+    for (const label of ["Всички", "Да", "Не", "Не се предлага"]) {
+      await expect(
+        page
+          .getByRole("menuitem")
+          .filter({ hasText: new RegExp(`^${label}$`) }),
+      ).toBeVisible();
+    }
+    await expect(page.getByRole("menuitem")).toHaveCount(4);
+  });
+
+  test("'Не' offers only coins the collector could actually go and get", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/coins/list?filters[location]=all&filters[collected]=not-collected",
+    );
+    await expect(page.locator("ul[role='list'] li").first()).toBeVisible({
+      timeout: 10000,
+    });
+
+    await expect(page.locator("[data-testid='unavailable-badge']")).toHaveCount(
+      0,
+    );
+    await expect(page.locator("[data-testid='collected-badge']")).toHaveCount(
+      0,
+    );
+  });
+
+  test("'Не се предлага' keeps the excluded coins reachable, each showing why", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/coins/list?filters[location]=all&filters[collected]=not-available",
+    );
+    const cards = page.locator("ul[role='list'] li");
+    await expect(cards.first()).toBeVisible({ timeout: 10000 });
+
+    // Every card must justify its own presence, or the view contradicts the
+    // filter the collector chose.
+    await expect(page.locator("[data-testid='unavailable-badge']")).toHaveCount(
+      await cards.count(),
+    );
+  });
+
+  test("'Не' and 'Не се предлага' together account for every uncollected coin", async ({
+    page,
+  }) => {
+    const countFor = async (filter: string) => {
+      await page.goto(
+        `/coins/list?filters[location]=all&filters[collected]=${filter}`,
+      );
+      await expect(page.locator("ul[role='list'] li").first()).toBeVisible({
+        timeout: 10000,
+      });
+      return page.locator("ul[role='list'] li").count();
+    };
+
+    const all = await countFor("all");
+    const collected = await countFor("collected");
+    const notCollected = await countFor("not-collected");
+    const notAvailable = await countFor("not-available");
+
+    expect(notCollected).toBeLessThan(all - collected);
+    expect(notCollected + notAvailable).toBe(all - collected);
+  });
+
+  test("a link bookmarked with the old yes value falls back to showing every coin", async ({
+    page,
+  }) => {
+    await page.goto("/coins/list?filters[location]=all&filters[collected]=yes");
+    await expect(page.locator("ul[role='list'] li").first()).toBeVisible({
+      timeout: 10000,
+    });
+    const fallback = await page.locator("ul[role='list'] li").count();
+
+    await page.goto("/coins/list?filters[location]=all&filters[collected]=all");
+    await expect(page.locator("ul[role='list'] li").first()).toBeVisible({
+      timeout: 10000,
+    });
+
+    expect(fallback).toBe(await page.locator("ul[role='list'] li").count());
   });
 
   test("coins that cannot currently be collected explain why in the list", async ({


### PR DESCRIPTION
Closes #62. Third slice of the coin availability PRD (#59), on top of #64 and #65.

## What changed

The coins "Събрани" filter becomes the same four-value set the sites марка filter already uses, so there is one vocabulary to learn rather than two.

- **`coinStatus` gains the filter tuple, its parser and the matcher** — `COIN_FILTER_VALUES`, `toCoinFilterValue`, `matchesCoinFilter`. This completes the extraction begun in #64: the hook no longer compares fields against magic strings, it asks the module.
- **"Не" narrows to what can actually be collected.** It now means *not collected and obtainable*, so the trip-planning list only contains achievable stops. The excluded coins stay reachable under the new **"Не се предлага"**, rather than silently disappearing.
- **URL values renamed** from `yes`/`no` to `collected`/`not-collected`/`not-available`. Mixing `yes`/`no` with `not-available` would be an incoherent set. Links bookmarked with the old values fall back to "all" — accepted in the PRD.
- `not-available` matches on availability **regardless of collection**, keeping the two axes independent.

## Verification

Drove the real app rather than trusting the tests, and the behaviour is right — but **the numbers in the ticket are stale**:

| filter | cards | unavailable badges |
|---|---|---|
| Всички | 169 | 5 |
| Да | 25 | 0 |
| **Не** | **139** | 0 |
| Не се предлага | 5 | 5 |

The ticket says "Не" returns 135. It returns 139, because the arithmetic assumed 29 collected coins and the data currently has 25: `169 − 25 − 5 = 139`. The behaviour the number was standing in for is correct — "Не" excludes exactly the 5 unavailable coins (144 → 139), and all 5 remain reachable under "Не се предлага", each showing its badge. Same data drift I noted on #64.

- Module tests extend the existing matrix to all four filter values across all four coin states, plus the parser's fallback for the retired `yes`/`no` values.
- Hook tests gain an uncollected-unavailable and a collected-unavailable fixture coin, covering the four values, the fallback, and composition with the location filter.
- Five new e2e tests: the four options, "Не" containing no unavailable coin, every "Не се предлага" card justifying its presence, the two partitioning the uncollected set, and an old bookmarked link falling back.
- 160 unit tests, 60 e2e, `tsc --noEmit` and `eslint` all pass.

## Note

`{coin.collected && …}` still reads the field directly in the list card and the map popup — the last of the inlined logic the PRD's "extraction is complete, not partial" refers to. It is left for #63, which rewrites exactly those two blocks to render both badges together.