### PR TITLE
Show availability on collected coins that are no longer offered

### DIFF
--- a/src/app/coins/map/__tests__/page.test.tsx
+++ b/src/app/coins/map/__tests__/page.test.tsx
@@ -177,6 +177,18 @@ describe("CoinsMapPage", () => {
       );
     });
 
+    it("tells a collected coin that is no longer offered both facts", () => {
+      const pin = capturedPins.find((p) => p.key === "6")!;
+      const { getByTestId, getByText } = render(
+        pin.popup as React.ReactElement,
+      );
+
+      expect(getByText("Събрана")).toBeInTheDocument();
+      expect(getByTestId("unavailable-badge")).toHaveTextContent(
+        "В момента не се предлага",
+      );
+    });
+
     it("keeps the product link usable on a coin that is no longer offered", () => {
       const pin = capturedPins.find((p) => p.key === "5")!;
       const { getByRole } = render(pin.popup as React.ReactElement);

--- a/src/components/CoinAvailability.tsx
+++ b/src/components/CoinAvailability.tsx
@@ -6,6 +6,9 @@ import { coinIsUnavailable, type CoinState } from "@/lib/coinStatus";
  * "в момента" is load-bearing: a coin can start being offered again, and the
  * collector should re-check rather than write it off. The filter option says
  * the shorter "Не се предлага" because it sits among other short labels.
+ *
+ * Read independently of `collected`: an owned coin that stopped being offered
+ * shows both facts, unlike the pin, which has one slot and lets collected win.
  */
 const MESSAGE = "В момента не се предлага";
 
@@ -18,7 +21,7 @@ export const CoinAvailability = ({
   state,
   className,
 }: CoinAvailabilityProps) => {
-  if (state.collected || !coinIsUnavailable(state)) {
+  if (!coinIsUnavailable(state)) {
     return null;
   }
 

--- a/src/components/__tests__/CoinAvailability.test.tsx
+++ b/src/components/__tests__/CoinAvailability.test.tsx
@@ -24,18 +24,31 @@ describe("CoinAvailability", () => {
     expect(screen.queryByTestId("unavailable-badge")).toBeNull();
   });
 
-  it("says nothing about a collected coin", () => {
+  it("says nothing about a collected coin that is still offered", () => {
     render(<CoinAvailability state={state(true, true)} />);
 
     expect(screen.queryByTestId("unavailable-badge")).toBeNull();
   });
 
-  // Deliberate, not an oversight: a collected coin says nothing about
-  // availability, matching the pin, which also lets collected win.
-  it("stays silent on a collected coin that is no longer offered", () => {
+  // No coin is in this state in the shipped data, so this test is the only
+  // place the rule is exercised.
+  it("tells a collected coin that it is no longer offered", () => {
     render(<CoinAvailability state={state(true, false)} />);
 
-    expect(screen.queryByTestId("unavailable-badge")).toBeNull();
+    expect(screen.getByTestId("unavailable-badge")).toBeInTheDocument();
+  });
+
+  it("uses one string whether or not the coin is collected", () => {
+    render(
+      <>
+        <CoinAvailability state={state(false, false)} />
+        <CoinAvailability state={state(true, false)} />
+      </>,
+    );
+
+    const [uncollected, collected] = screen.getAllByTestId("unavailable-badge");
+
+    expect(collected.textContent).toBe(uncollected.textContent);
   });
 
   it("keeps the temporal qualifier, so the collector re-checks rather than gives up", () => {


### PR DESCRIPTION
Closes #63

## What changed

`CoinAvailability` gated itself on `collected`, so an owned coin that stopped being offered rendered nothing. The gate is gone — the badge is now driven purely by the availability predicate, as the parent PRD (#59) specifies under *Where the collapse happens*: pin colour collapses, text does not.

Both call sites already rendered the badge unconditionally alongside the collected badge, so the component was the only change needed.

## Why it matters beyond the badge

Without this, the "Не се предлага" filter from #62 could return a card showing a green check and no explanation of why it matched.

## Tests

No coin in the shipped data is both collected and unavailable, so this is only reachable through fixtures:

- `CoinAvailability` — a collected, unavailable coin gets the badge; the string is identical whether or not the coin is collected.
- Coins map popup — the collected-and-unavailable fixture shows *both* "Събрана" and "В момента не се предлага".
- `coinStatus` already covered the predicate and the derived pin status for all four states; unchanged.

`npm test`, `npx tsc --noEmit`, `npm run lint` and `npm run test:e2e` (59 passed) all green.