### PR TITLE
fix(sites): make useSiteFilters read the URL instead of mirroring it

### DIFF
--- a/src/hooks/__tests__/useSiteFilters.test.tsx
+++ b/src/hooks/__tests__/useSiteFilters.test.tsx
@@ -1,14 +1,14 @@
-import { renderHook, act } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const pushMock = vi.fn();
+const replaceMock = vi.fn();
 
 let searchParamsRef: { get: (key: string) => string | null } = {
   get: () => null,
 };
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: pushMock }),
+  useRouter: () => ({ replace: replaceMock }),
   useSearchParams: () => searchParamsRef,
 }));
 
@@ -64,7 +64,7 @@ const siteNames = (
 
 describe("useSiteFilters", () => {
   beforeEach(() => {
-    pushMock.mockClear();
+    replaceMock.mockClear();
     searchParamsRef = { get: () => null };
   });
 
@@ -328,14 +328,14 @@ describe("useSiteFilters", () => {
       );
     });
 
-    it("carries a sticker selection made after mount into the query string", () => {
+    it("replaces the URL with a sticker selection, preserving the other filters", () => {
+      withParams({ "filters[location]": "Банско", "filters[stamp]": "collected" });
       const { result } = renderHook(() => useSiteFilters());
 
-      act(() => result.current.setStickerFilter("not-available"));
+      result.current.setStickerFilter("not-available");
 
-      expect(result.current.stickerFilter).toBe("not-available");
-      expect(result.current.queryString).toContain(
-        "filters[sticker]=not-available",
+      expect(replaceMock).toHaveBeenCalledWith(
+        `?filters[location]=${encodeURIComponent("Банско")}&filters[stamp]=collected&filters[sticker]=not-available`,
       );
     });
 
@@ -347,22 +347,51 @@ describe("useSiteFilters", () => {
       expect(siteNames(result.current.filteredData)).toHaveLength(5);
     });
 
-    it("carries a selection made after mount into the query string", () => {
+    it("normalises an unsupported sticker value instead of writing it to the URL", () => {
       const { result } = renderHook(() => useSiteFilters());
 
-      act(() => result.current.setStampFilter("collected"));
+      result.current.setStickerFilter("nonsense");
 
-      expect(result.current.stampFilter).toBe("collected");
-      expect(result.current.queryString).toContain("filters[stamp]=collected");
+      expect(replaceMock).toHaveBeenCalledWith(
+        "?filters[location]=all&filters[stamp]=all&filters[sticker]=all",
+      );
     });
 
-    it("pushes the query string so the selection survives a view switch", () => {
+    it("replaces the URL with a stamp selection, preserving the other filters", () => {
+      withParams({ "filters[sticker]": "collected" });
+      const { result } = renderHook(() => useSiteFilters());
+
+      result.current.setStampFilter("collected");
+
+      expect(replaceMock).toHaveBeenCalledWith(
+        "?filters[location]=all&filters[stamp]=collected&filters[sticker]=collected",
+      );
+    });
+
+    it("does not touch history on mount", () => {
       withParams({ "filters[stamp]": "collected" });
       renderHook(() => useSiteFilters());
 
-      expect(pushMock).toHaveBeenCalledWith(
-        "?filters[location]=all&filters[stamp]=collected&filters[sticker]=all",
-      );
+      expect(replaceMock).not.toHaveBeenCalled();
+    });
+
+    it("reflects updated URL params on re-render (back/forward navigation)", () => {
+      const { result, rerender } = renderHook(() => useSiteFilters());
+
+      expect(result.current.selectedLocation).toBe("all");
+      expect(result.current.stampFilter).toBe("all");
+      expect(result.current.stickerFilter).toBe("all");
+
+      withParams({
+        "filters[location]": "Банско",
+        "filters[stamp]": "collected",
+        "filters[sticker]": "not-collected",
+      });
+      rerender();
+
+      expect(result.current.selectedLocation).toBe("Банско");
+      expect(result.current.stampFilter).toBe("collected");
+      expect(result.current.stickerFilter).toBe("not-collected");
     });
   });
 

--- a/src/hooks/useSiteFilters.ts
+++ b/src/hooks/useSiteFilters.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import data from "@/data/places.json";
 import {
@@ -12,37 +12,41 @@ import {
   type StickerFilterValue,
 } from "@/lib/collectionStatus";
 
+const buildQuery = (
+  location: string,
+  stamp: StampFilterValue,
+  sticker: StickerFilterValue,
+) =>
+  `filters[location]=${encodeURIComponent(location)}&filters[stamp]=${encodeURIComponent(stamp)}&filters[sticker]=${encodeURIComponent(sticker)}`;
+
 export function useSiteFilters() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const initialLocation = searchParams.get("filters[location]") || "all";
+  const selectedLocation = searchParams.get("filters[location]") || "all";
   // A stale link carrying the removed visited parameter simply falls back to
   // the default selection; no alias is provided.
-  const initialStampFilter = toStampFilterValue(
-    searchParams.get("filters[stamp]")
-  );
-  const initialStickerFilter = toStickerFilterValue(
-    searchParams.get("filters[sticker]")
+  const stampFilter = toStampFilterValue(searchParams.get("filters[stamp]"));
+  const stickerFilter = toStickerFilterValue(
+    searchParams.get("filters[sticker]"),
   );
 
-  const [selectedLocation, setSelectedLocation] =
-    useState<string>(initialLocation);
-
-  const [stampFilter, setStampFilterValue] =
-    useState<StampFilterValue>(initialStampFilter);
-
-  // The filter widget deals in plain strings; narrowing happens here so
-  // callers stay pure wiring.
-  const setStampFilter = (value: string) => {
-    setStampFilterValue(toStampFilterValue(value));
+  const setSelectedLocation = (value: string) => {
+    router.replace(`?${buildQuery(value, stampFilter, stickerFilter)}`);
   };
 
-  const [stickerFilter, setStickerFilterValue] =
-    useState<StickerFilterValue>(initialStickerFilter);
+  // The filter widget deals in plain strings; narrowing happens here so the URL
+  // can never disagree with the filter actually applied.
+  const setStampFilter = (value: string) => {
+    router.replace(
+      `?${buildQuery(selectedLocation, toStampFilterValue(value), stickerFilter)}`,
+    );
+  };
 
   const setStickerFilter = (value: string) => {
-    setStickerFilterValue(toStickerFilterValue(value));
+    router.replace(
+      `?${buildQuery(selectedLocation, stampFilter, toStickerFilterValue(value))}`,
+    );
   };
 
   const hasActiveFilters =
@@ -51,9 +55,7 @@ export function useSiteFilters() {
     stickerFilter !== "all";
 
   const clearFilters = () => {
-    setSelectedLocation("all");
-    setStampFilterValue("all");
-    setStickerFilterValue("all");
+    router.replace(`?${buildQuery("all", "all", "all")}`);
   };
 
   const citiesByRegion = useMemo(() => {
@@ -110,11 +112,7 @@ export function useSiteFilters() {
     [selectedLocation, stampFilter, stickerFilter]
   );
 
-  const queryString = `filters[location]=${encodeURIComponent(selectedLocation)}&filters[stamp]=${encodeURIComponent(stampFilter)}&filters[sticker]=${encodeURIComponent(stickerFilter)}`;
-
-  useEffect(() => {
-    router.push(`?${queryString}`);
-  }, [queryString, router]);
+  const queryString = buildQuery(selectedLocation, stampFilter, stickerFilter);
 
   return {
     selectedLocation,


### PR DESCRIPTION
Closes #56.

`useSiteFilters` kept filter state in `useState` and pushed it to the URL from an effect, unlike its sibling `useCoinsFilters`. That caused the three problems the issue describes:

1. **Pushed on mount** — landing on `/sites/list` with a bare URL immediately navigated to the fully-expanded query string, spending a history entry before the user acted.
2. **Every filter change was a history entry** — it used `push`, not `replace`, so changing city → печат → марка required three Backs to leave.
3. **State could diverge** — the params were read only for initial values, so an external URL change (back/forward, shared link) never reached the filters.

## Change

- Derive `selectedLocation`, `stampFilter` and `stickerFilter` straight from `useSearchParams`.
- Drop the `useState` trio and the `useEffect`.
- Each setter (and `clearFilters`) `router.replace`s the full query string, built through a small `buildQuery` helper so `queryString` and the setters cannot drift.

This mirrors `useCoinsFilters`. Switching list/map still preserves filters through `queryString`, and a back/forward navigation now flows back into the filters.

## Tests

`src/hooks/__tests__/useSiteFilters.test.tsx` updated to the new contract:

- Router mock switched from `push` to `replace`.
- The two "carries a selection after mount" tests (which relied on `useState` re-rendering) now assert `router.replace` is called with the correct query string, preserving the sibling filters.
- Mount-push test replaced with "does not touch history on mount".
- Added a back/forward re-render test proving the URL flows back into the filters.

Full suite: 170 passed. `tsc --noEmit` and `eslint` clean. React Doctor no longer flags the client-side redirect.